### PR TITLE
Add logging to Maven crawler and update dependencies

### DIFF
--- a/plugins/maven-crawler/pom.xml
+++ b/plugins/maven-crawler/pom.xml
@@ -26,17 +26,25 @@
             <artifactId>indexer-core</artifactId>
             <version>6.0.0</version>
         </dependency>
-        <!-- the "shaded" indexer-cli contains incompatible class definitions, load this first -->
-        <!-- TODO: replace the index-cli dependency -->
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>3.8.4</version>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.inject</artifactId>
+            <version>0.3.5</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.indexer</groupId>
-            <artifactId>indexer-cli</artifactId>
-            <version>6.0.0</version>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.plexus</artifactId>
+            <version>0.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.4.1</version>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
Minor extension to the `maven-crawler` that replaces the bloated dependency to `indexer-cli` with the original dependencies. This allowed us to update the dependencies and to get rid of an issue caused by an embedded class that caused conflicts.

I have also added some basic logging statements to the Maven crawler.