### PR TITLE
Do not trigger builds a second time in PRs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,10 +1,8 @@
 name: Verify
 
-# no trigger on tags
+# no trigger on tags, PRs already covered by the previous push
 on:
   push:
-    branches: ['**']
-  pull_request:
     branches: ['**']
 
 jobs:


### PR DESCRIPTION
The `verify` workflow is already triggered "on push"... there is no need to trigger it a second time when opening a PR. We can review this decision should we start receiving a lot of PRs from external repos.