### PR TITLE
Final touches for the pom-analyzer prod release

### DIFF
--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraArgs.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraArgs.java
@@ -33,6 +33,6 @@ public class InfraArgs {
     @Parameter(names = "--kafka.url", arity = 1, description = "address for the Kafka Server")
     public String kafkaUrl;
 
-    @Parameter(names = "--instanceId", arity = 1, description = "uniquely identifies this instance of the application")
+    @Parameter(names = "--instanceId", arity = 1, description = "uniquely identifies this application instance across re-starts")
     public String instanceId = null;
 }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
@@ -117,7 +117,12 @@ public class Resolver {
 
     private static Set<ResolutionResult> toResolutionResult(Set<String[]> res) {
         return res.stream() //
-                .map(a -> new ResolutionResult(a[0], a[1], new File(a[2]))) //
+                .map(a -> {
+                    if (!a[1].endsWith("/")) {
+                        a[1] += "/";
+                    }
+                    return new ResolutionResult(a[0], a[1], new File(a[2]));
+                }) //
                 .collect(Collectors.toSet());
     }
 }

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
@@ -66,6 +66,17 @@ public class ResolverTest {
     }
 
     @Test
+    public void resolveDirectDependenciesWithTraiilingSlash() {
+        var actual = resolveTestPom("basic-with-trailing-repo-slashes.pom");
+        var expected = new HashSet<ResolutionResult>();
+        expected.add(JSR305);
+        expected.add(COMMONS_LANG3);
+        expected.add(REMLA);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void defaultConfigAddsEverything() {
         sut = new Resolver();
         resolveDirectDependencies();
@@ -108,22 +119,22 @@ public class ResolverTest {
 
     private static final ResolutionResult JSR305 = new ResolutionResult(//
             "com.google.code.findbugs:jsr305:jar:3.0.2", //
-            "https://repo.maven.apache.org/maven2", //
+            "https://repo.maven.apache.org/maven2/", //
             new File("/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom"));
 
     private static final ResolutionResult COMMONS_LANG3 = new ResolutionResult(//
             "org.apache.commons:commons-lang3:jar:3.9", //
-            "https://repo.maven.apache.org/maven2", //
+            "https://repo.maven.apache.org/maven2/", //
             new File("/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.pom"));
 
     private static final ResolutionResult COMMONS_TEXT = new ResolutionResult(//
             "org.apache.commons:commons-text:jar:1.8", //
-            "https://repo.maven.apache.org/maven2", //
+            "https://repo.maven.apache.org/maven2/", //
             new File("/org/apache/commons/commons-text/1.8/commons-text-1.8.pom"));
 
     private static final ResolutionResult REMLA = new ResolutionResult(//
             "remla:mylib:jar:0.0.5", //
-            "https://gitlab.com/api/v4/projects/26117144/packages/maven", //
+            "https://gitlab.com/api/v4/projects/26117144/packages/maven/", //
             new File("/remla/mylib/0.0.5/mylib-0.0.5.pom"));
 
     private Set<ResolutionResult> resolveTestPom(String pathToPom) {

--- a/plugins/pom-analyzer/src/test/resources/ResolverTest/basic-with-trailing-repo-slashes.pom
+++ b/plugins/pom-analyzer/src/test/resources/ResolverTest/basic-with-trailing-repo-slashes.pom
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>test</groupId>
+	<artifactId>ResolverTest</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<repositories>
+		<repository>
+			<id>gitlab-maven</id>
+			<url>https://gitlab.com/api/v4/projects/26117144/packages/maven/</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<!-- Maven Central -->
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.9</version>
+		</dependency>
+
+		<!-- GitLab Custom Repo -->
+		<dependency>
+			<groupId>remla</groupId>
+			<artifactId>mylib</artifactId>
+			<version>0.0.5</version>
+		</dependency>
+	</dependencies>
+</project>


### PR DESCRIPTION
Upon further manual testing in the docker-compose environment, I found that the artifactRepositories that are discovered by Shrinkwrap do not automatically have a trailing slash in the URL, which leads to failed downloads and crashes downstream. I added a test and a fix for these cases.

Furthermore, I improved the explanation for the --instanceId argument.