### PR TITLE
Tackling the ongoing slow-down in the processing pipeline

### DIFF
--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnectionError.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnectionError.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.kafka;
+
+public class KafkaConnectionError extends RuntimeException {
+
+    private static final long serialVersionUID = -5060764034291589459L;
+
+    public KafkaConnectionError() {
+        super();
+    }
+
+    public KafkaConnectionError(String msg) {
+        super(msg);
+    }
+
+    public KafkaConnectionError(Throwable t) {
+        super(t);
+    }
+
+    public KafkaConnectionError(String msg, Throwable t) {
+        super(msg, t);
+    }
+}

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
@@ -27,7 +27,6 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_INSTANCE_ID
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 
 import java.security.InvalidParameterException;
@@ -52,8 +51,11 @@ import eu.f4sten.infra.kafka.Lane;
 public class KafkaConnector {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaConnector.class);
+
     private static final String MAX_REQUEST_SIZE = valueOf(50 * 1024 * 1024); // 50MB
-    private static final String MAX_POLL_INTERVAL = valueOf(1000 * 60 * 30); // 30min
+    private static final String MAX_POLL_INTERVAL_MS = valueOf(1000 * 60 * 30); // 30min
+    private static final String SESSION_TIMEOUT_MS = valueOf(1000 * 10); // 10s
+    private static final String HEARTBEAT_INTERVAL_MS = valueOf(1000 * 3); // 3s
 
     private final String activePlugin;
     private final InfraArgs args;
@@ -85,9 +87,7 @@ public class KafkaConnector {
         p.setProperty(FETCH_MAX_BYTES_CONFIG, MAX_REQUEST_SIZE);
         p.setProperty(MAX_POLL_RECORDS_CONFIG, "1");
 
-        // make sure to set group.{min, max}.session.timeout.ms for brokers
-        p.setProperty(SESSION_TIMEOUT_MS_CONFIG, MAX_POLL_INTERVAL);
-        p.setProperty(MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL);
+        p.setProperty(MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS);
 
         var instanceId = getFullInstanceId(l);
         if (instanceId != null) {

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
@@ -54,8 +54,6 @@ public class KafkaConnector {
 
     private static final String MAX_REQUEST_SIZE = valueOf(50 * 1024 * 1024); // 50MB
     private static final String MAX_POLL_INTERVAL_MS = valueOf(1000 * 60 * 30); // 30min
-    private static final String SESSION_TIMEOUT_MS = valueOf(1000 * 10); // 10s
-    private static final String HEARTBEAT_INTERVAL_MS = valueOf(1000 * 3); // 3s
 
     private final String activePlugin;
     private final InfraArgs args;

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
@@ -75,7 +75,7 @@ public class KafkaConnector {
     public Properties getConsumerProperties(Lane l) {
         Properties p = new Properties();
         p.setProperty(BOOTSTRAP_SERVERS_CONFIG, args.kafkaUrl);
-        p.setProperty(GROUP_ID_CONFIG, activePlugin);
+        p.setProperty(GROUP_ID_CONFIG, format("%s-%s", activePlugin, l));
         p.setProperty(AUTO_OFFSET_RESET_CONFIG, "earliest");
         p.setProperty(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         p.setProperty(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaGracefulShutdownThread.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaGracefulShutdownThread.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.f4sten.infra.kafka.Kafka;
+
+public class KafkaGracefulShutdownThread extends Thread {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaGracefulShutdownThread.class);
+
+    private Kafka kafka;
+
+    public KafkaGracefulShutdownThread(Kafka kafka) {
+        this.kafka = kafka;
+    }
+
+    @Override
+    public void run() {
+        LOG.info("Gracefully stopping all Kafka connections ...");
+        kafka.stop();
+    }
+}

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaImpl.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaImpl.java
@@ -207,10 +207,10 @@ public class KafkaImpl implements Kafka {
             try {
                 obj = deserializer.apply(json);
                 callback.accept(obj, lane);
-            } catch (Throwable t) {
-                LOG.error("Unhandled exception in callback", t);
+            } catch (Exception e) {
+                LOG.error("Unhandled exception in callback", e);
                 var baseTopic = baseTopics.get(combinedTopic);
-                var err = errors.apply(obj, t);
+                var err = errors.apply(obj, e);
                 // check instance equality!
                 if (err != NONE) {
                     publish(err, baseTopic, ERROR);

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
@@ -15,7 +15,6 @@
  */
 package eu.f4sten.infra.impl.kafka;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static eu.f4sten.infra.kafka.Lane.NORMAL;
 import static eu.f4sten.infra.kafka.Lane.PRIORITY;
@@ -45,8 +44,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.github.stefanbirkner.systemlambda.SystemLambda;
-
+import eu.f4sten.infra.AssertArgsError;
 import eu.f4sten.infra.LoaderArgs;
 import eu.f4sten.infra.impl.InfraArgs;
 import eu.f4sten.infra.kafka.Lane;
@@ -73,7 +71,7 @@ public class KafkaConnectorTest {
     public void inputValidationKafkaUrlMustNotBeNull() throws Exception {
         var infraArgs = new InfraArgs();
         var out = tapSystemOut(() -> {
-            SystemLambda.catchSystemExit(() -> {
+            assertThrows(AssertArgsError.class, () -> {
                 new KafkaConnector(loaderArgs, infraArgs);
             });
         });
@@ -87,7 +85,7 @@ public class KafkaConnectorTest {
 
         infraArgs.instanceId = "";
         var out = tapSystemOut(() -> {
-            catchSystemExit(() -> {
+            assertThrows(AssertArgsError.class, () -> {
                 new KafkaConnector(loaderArgs, infraArgs);
             });
         });

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
@@ -19,11 +19,14 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static eu.f4sten.infra.kafka.Lane.NORMAL;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.FETCH_MAX_BYTES_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_INSTANCE_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -116,6 +119,8 @@ public class KafkaConnectorTest {
             expected.setProperty(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
             expected.setProperty(FETCH_MAX_BYTES_CONFIG, Integer.toString(50 * 1024 * 1024));
             expected.setProperty(MAX_POLL_RECORDS_CONFIG, "1");
+            expected.setProperty(SESSION_TIMEOUT_MS_CONFIG, Integer.toString(1000 * 60 * 30));
+            expected.setProperty(MAX_POLL_INTERVAL_MS_CONFIG, Integer.toString(1000 * 60 * 30));
 
             assertEquals(expected, actual);
         }
@@ -125,9 +130,10 @@ public class KafkaConnectorTest {
     public void instanceIdIsSet() {
         infraArgs.instanceId = "X";
         for (var l : Lane.values()) {
-            var actual = sut.getConsumerProperties(l).get(GROUP_INSTANCE_ID_CONFIG);
             var expected = "p-X-" + l;
-            assertEquals(expected, actual);
+            var actual = sut.getConsumerProperties(l);
+            assertEquals(expected, actual.get(CLIENT_ID_CONFIG));
+            assertEquals(expected, actual.get(GROUP_INSTANCE_ID_CONFIG));
         }
     }
 

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
@@ -27,7 +27,6 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_INSTANCE_ID
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -123,7 +122,6 @@ public class KafkaConnectorTest {
             expected.setProperty(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
             expected.setProperty(FETCH_MAX_BYTES_CONFIG, Integer.toString(50 * 1024 * 1024));
             expected.setProperty(MAX_POLL_RECORDS_CONFIG, "1");
-            expected.setProperty(SESSION_TIMEOUT_MS_CONFIG, Integer.toString(1000 * 60 * 30));
             expected.setProperty(MAX_POLL_INTERVAL_MS_CONFIG, Integer.toString(1000 * 60 * 30));
 
             assertEquals(expected, actual);

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
@@ -18,6 +18,7 @@ package eu.f4sten.infra.impl.kafka;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static eu.f4sten.infra.kafka.Lane.NORMAL;
+import static java.lang.String.format;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.FETCH_MAX_BYTES_CONFIG;
@@ -54,6 +55,7 @@ import eu.f4sten.infra.kafka.Lane;
 public class KafkaConnectorTest {
 
     private static final String KAFKA_URL = "1.2.3.4:1234";
+    private static final String SOME_PLUGIN = "p";
 
     private LoaderArgs loaderArgs;
     private InfraArgs infraArgs;
@@ -62,7 +64,7 @@ public class KafkaConnectorTest {
     @BeforeEach
     public void setup() {
         loaderArgs = new LoaderArgs();
-        loaderArgs.plugin = "p";
+        loaderArgs.plugin = SOME_PLUGIN;
         infraArgs = new InfraArgs();
         infraArgs.kafkaUrl = KAFKA_URL;
         sut = new KafkaConnector(loaderArgs, infraArgs);
@@ -113,7 +115,7 @@ public class KafkaConnectorTest {
 
             Properties expected = new Properties();
             expected.setProperty(BOOTSTRAP_SERVERS_CONFIG, infraArgs.kafkaUrl);
-            expected.setProperty(GROUP_ID_CONFIG, loaderArgs.plugin);
+            expected.setProperty(GROUP_ID_CONFIG, format("%s-%s", SOME_PLUGIN, l));
             expected.setProperty(AUTO_OFFSET_RESET_CONFIG, "earliest");
             expected.setProperty(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
             expected.setProperty(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaGracefulShutdownThreadTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaGracefulShutdownThreadTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.kafka;
+
+import static eu.f4sten.test.TestLoggerUtils.assertLogsContain;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import eu.f4sten.infra.kafka.Kafka;
+import eu.f4sten.test.TestLoggerUtils;
+
+public class KafkaGracefulShutdownThreadTest {
+
+    private Kafka kafka;
+    private KafkaGracefulShutdownThread sut;
+
+    @BeforeEach
+    public void setup() {
+        TestLoggerUtils.clearLog();
+        kafka = mock(Kafka.class);
+        sut = new KafkaGracefulShutdownThread(kafka);
+    }
+
+    @Test
+    public void whenExecutedShutdownKafka() {
+        sut.run();
+        verify(kafka).stop();
+    }
+
+    @Test
+    public void shutdownIsLogged() {
+        sut.run();
+        assertLogsContain(KafkaGracefulShutdownThread.class, "INFO Gracefully stopping all Kafka connections ...");
+    }
+}

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaImplTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaImplTest.java
@@ -95,45 +95,45 @@ public class KafkaImplTest {
     @Test
     public void subscribesEndUpAtConnection_Class() {
         sut.subscribe("t", String.class, SOME_CB);
-        verify(consumerNorm).subscribe(Set.of("t.out"));
-        verify(consumerPrio).subscribe(Set.of("t.priority.out"));
+        verifySubscribe(consumerNorm, "t.out");
+        verifySubscribe(consumerPrio, "t.priority.out");
 
         sut.subscribe("t2", String.class, SOME_CB);
-        verify(consumerNorm, times(2)).subscribe(Set.of("t.out", "t2.out"));
-        verify(consumerPrio, times(2)).subscribe(Set.of("t.priority.out", "t2.priority.out"));
+        verifySubscribe(consumerNorm, 2, "t.out", "t2.out");
+        verifySubscribe(consumerPrio, 2, "t.priority.out", "t2.priority.out");
     }
 
     @Test
     public void subscribesEndUpAtConnection_ClassErr() {
         sut.subscribe("t", String.class, SOME_CB, SOME_ERR_CB);
-        verify(consumerNorm).subscribe(Set.of("t.out"));
-        verify(consumerPrio).subscribe(Set.of("t.priority.out"));
+        verifySubscribe(consumerNorm, "t.out");
+        verifySubscribe(consumerPrio, "t.priority.out");
 
         sut.subscribe("t2", String.class, SOME_CB, SOME_ERR_CB);
-        verify(consumerNorm, times(2)).subscribe(Set.of("t.out", "t2.out"));
-        verify(consumerPrio, times(2)).subscribe(Set.of("t.priority.out", "t2.priority.out"));
+        verifySubscribe(consumerNorm, 2, "t.out", "t2.out");
+        verifySubscribe(consumerPrio, 2, "t.priority.out", "t2.priority.out");
     }
 
     @Test
     public void subscribesEndUpAtConnection_TRef() {
         sut.subscribe("t", T_STRING, SOME_CB);
-        verify(consumerNorm).subscribe(Set.of("t.out"));
-        verify(consumerPrio).subscribe(Set.of("t.priority.out"));
+        verifySubscribe(consumerNorm, "t.out");
+        verifySubscribe(consumerPrio, "t.priority.out");
 
         sut.subscribe("t2", T_STRING, SOME_CB, SOME_ERR_CB);
-        verify(consumerNorm, times(2)).subscribe(Set.of("t.out", "t2.out"));
-        verify(consumerPrio, times(2)).subscribe(Set.of("t.priority.out", "t2.priority.out"));
+        verifySubscribe(consumerNorm, 2, "t.out", "t2.out");
+        verifySubscribe(consumerPrio, 2, "t.priority.out", "t2.priority.out");
     }
 
     @Test
     public void subscribesEndUpAtConnection_TRefErr() {
         sut.subscribe("t", T_STRING, SOME_CB, SOME_ERR_CB);
-        verify(consumerNorm).subscribe(Set.of("t.out"));
-        verify(consumerPrio).subscribe(Set.of("t.priority.out"));
+        verifySubscribe(consumerNorm, "t.out");
+        verifySubscribe(consumerPrio, "t.priority.out");
 
         sut.subscribe("t2", T_STRING, SOME_CB, SOME_ERR_CB);
-        verify(consumerNorm, times(2)).subscribe(Set.of("t.out", "t2.out"));
-        verify(consumerPrio, times(2)).subscribe(Set.of("t.priority.out", "t2.priority.out"));
+        verifySubscribe(consumerNorm, 2, "t.out", "t2.out");
+        verifySubscribe(consumerPrio, 2, "t.priority.out", "t2.priority.out");
     }
 
     @Test
@@ -190,7 +190,7 @@ public class KafkaImplTest {
         verify(consumerPrio).commitSync();
 
         // heartbeat
-        verify(consumerNorm).subscribe(Set.of("t.out"));
+        verifySubscribe(consumerNorm, "t.out");
         verify(consumerNorm).assignment();
         verify(consumerNorm).pause(anySet());
         verify(consumerNorm).poll(Duration.ZERO);
@@ -289,5 +289,13 @@ public class KafkaImplTest {
         when(jsonUtils.toJson(eq(o))).thenReturn(rnd);
         when(jsonUtils.fromJson(eq(rnd), any(Class.class))).thenReturn(o);
         when(jsonUtils.fromJson(eq(rnd), any(TRef.class))).thenReturn(o);
+    }
+
+    private static void verifySubscribe(KafkaConsumer<String, String> con, String... topics) {
+        verifySubscribe(con, 1, topics);
+    }
+
+    private static void verifySubscribe(KafkaConsumer<String, String> con, int times, String... topics) {
+        verify(con, times(times)).subscribe(eq(Set.of(topics)));
     }
 }

--- a/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/AssertArgs.java
+++ b/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/AssertArgs.java
@@ -77,7 +77,7 @@ public class AssertArgs {
             var jc = new JCommander(defaultArgObj);
             jc.setUsageFormatter(new MyUsageFormatter(jc));
             jc.usage();
-            System.exit(1);
+            throw new AssertArgsError();
         }
 
         private static <T> Object newInstance(T obj) {

--- a/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/AssertArgsError.java
+++ b/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/AssertArgsError.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra;
+
+public class AssertArgsError extends Error {
+
+    private static final long serialVersionUID = 6276649947210643670L;
+
+}

--- a/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/kafka/Kafka.java
+++ b/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/kafka/Kafka.java
@@ -24,6 +24,8 @@ public interface Kafka {
 
     void sendHeartbeat();
 
+    void stop();
+
     <T> void subscribe(String topic, Class<T> type, BiConsumer<T, Lane> callback);
 
     <T> void subscribe(String topic, Class<T> type, BiConsumer<T, Lane> callback, BiFunction<T, Throwable, ?> errors);

--- a/infrastructure/infrastructure/src/test/java/eu/f4sten/infra/AssertArgsTest.java
+++ b/infrastructure/infrastructure/src/test/java/eu/f4sten/infra/AssertArgsTest.java
@@ -15,7 +15,6 @@
  */
 package eu.f4sten.infra;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static eu.f4sten.infra.AssertArgs.TEXT_ERROR_INTRO;
 import static eu.f4sten.infra.AssertArgs.TEXT_GENERIC_ERROR;
@@ -98,7 +97,7 @@ public class AssertArgsTest {
     @Test
     public void noExceptionForNonJCommanderStructures() throws Exception {
         tapSystemOut(() -> {
-            catchSystemExit(() -> {
+            assertThrows(AssertArgsError.class, () -> {
                 AssertArgs.assertFor(new NoArgs()).that(o -> false, SOME_HINT);
             });
         });
@@ -120,9 +119,13 @@ public class AssertArgsTest {
 
     private static void assertErrorOutput(Statement s, String... expecteds) {
         assertOutput(() -> {
-            catchSystemExit(() -> {
+            var wasCalled = false;
+            try {
                 s.execute();
-            });
+            } catch (AssertArgsError e) {
+                wasCalled = true;
+            }
+            assertTrue(wasCalled);
         }, expecteds);
     }
 

--- a/infrastructure/loader/src/main/java/eu/f4sten/loader/Main.java
+++ b/infrastructure/loader/src/main/java/eu/f4sten/loader/Main.java
@@ -49,8 +49,9 @@ public class Main {
             // setup injector and run requested plugin
             var injector = Guice.createInjector(modules);
             injector.getInstance(pluginClass).run();
-        } catch (Error e) {
-            e.printStackTrace();
+        } catch (Throwable t) {
+            getLogger(Main.class).warn("Throwable caught in main loader class, shutting down VM ...");
+            t.printStackTrace();
             // make sure to tear down VM, including all running threads
             System.exit(1);
         }

--- a/infrastructure/loader/src/main/java/eu/f4sten/loader/Main.java
+++ b/infrastructure/loader/src/main/java/eu/f4sten/loader/Main.java
@@ -20,6 +20,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import com.google.inject.Guice;
 
 import eu.f4sten.infra.AssertArgs;
+import eu.f4sten.infra.AssertArgsError;
 import eu.f4sten.infra.InjectorConfig;
 import eu.f4sten.infra.LoaderArgs;
 import eu.f4sten.loader.utils.ArgsParser;
@@ -49,6 +50,8 @@ public class Main {
             // setup injector and run requested plugin
             var injector = Guice.createInjector(modules);
             injector.getInstance(pluginClass).run();
+        } catch (AssertArgsError e) {
+            System.exit(1);
         } catch (Throwable t) {
             getLogger(Main.class).warn("Throwable caught in main loader class, shutting down VM ...");
             t.printStackTrace();

--- a/infrastructure/loader/src/main/java/eu/f4sten/loader/utils/LoggingUtils.java
+++ b/infrastructure/loader/src/main/java/eu/f4sten/loader/utils/LoggingUtils.java
@@ -30,6 +30,8 @@ public class LoggingUtils {
     public void setLogLevel(LogLevel level) {
         // slf4j-simple
         System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, level.slf4j);
+        System.setProperty(org.slf4j.impl.SimpleLogger.SHOW_DATE_TIME_KEY, "true");
+        System.setProperty(org.slf4j.impl.SimpleLogger.DATE_TIME_FORMAT_KEY, "yyyy-MM-dd HH:mm:ss.SSS");
 
         // jul
         var lm = LogManager.getLogManager();

--- a/plugins/maven-crawler/src/test/java/eu/f4sten/mavencrawler/utils/LocalStoreTest.java
+++ b/plugins/maven-crawler/src/test/java/eu/f4sten/mavencrawler/utils/LocalStoreTest.java
@@ -15,10 +15,10 @@
  */
 package eu.f4sten.mavencrawler.utils;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import eu.f4sten.infra.AssertArgsError;
 import eu.f4sten.infra.utils.IoUtils;
 import eu.f4sten.mavencrawler.MavenCrawlerArgs;
 
@@ -87,7 +88,7 @@ public class LocalStoreTest {
         args.firstConsideredIndex = 0;
         new LocalStore(args, io);
         var out = tapSystemOut(() -> {
-            catchSystemExit(() -> {
+            assertThrows(AssertArgsError.class, () -> {
                 args.firstConsideredIndex = -1;
                 new LocalStore(args, io);
             });

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -167,7 +167,7 @@ public class Main implements Plugin {
         // 1) have dependencies
         // 2) identify artifact sources
         // 3) make sure all dependencies exist in local .m2 folder
-        var deps = resolver.resolveDependenciesFromPom(artifact.localPomFile);
+        var deps = resolver.resolveDependenciesFromPom(artifact.localPomFile, artifact.artifactRepository);
 
         // resolution can be different for dependencies, so 'process' them independently
         deps.forEach(dep -> {

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -87,7 +87,7 @@ public class Main implements Plugin {
         kafka.subscribe(args.kafkaIn, MavenId.class, (id, lane) -> {
             curId = id;
 
-            LOG.info("Consuming next record {} ...", asMavenCoordinate(id));
+            LOG.info("Consuming next record {} ...", id.asCoordinate());
             LOG.debug("{}", id);
             var artifact = bootstrapFirstResolutionResultFromInput(id);
             runAndCatch(artifact, lane, () -> {
@@ -127,7 +127,6 @@ public class Main implements Plugin {
     }
 
     private static ResolutionResult bootstrapFirstResolutionResultFromInput(MavenId id) {
-        var coord = asMavenCoordinate(id);
         var artifactRepository = MavenUtilities.MAVEN_CENTRAL_REPO;
         if (id.artifactRepository != null) {
             var val = id.artifactRepository.strip();
@@ -135,20 +134,10 @@ public class Main implements Plugin {
                 artifactRepository = val;
             }
         }
-        return new ResolutionResult(coord, artifactRepository);
+        return new ResolutionResult(id.asCoordinate(), artifactRepository);
     }
 
-    private static String asMavenCoordinate(MavenId id) {
-        Asserts.assertNotNull(id.groupId);
-        Asserts.assertNotNull(id.artifactId);
-        Asserts.assertNotNull(id.version);
 
-        var groupId = id.groupId.strip();
-        var artifactId = id.artifactId.strip();
-        var version = id.version.strip();
-        // packing type is unknown
-        return String.format("%s:%s:?:%s", groupId, artifactId, version);
-    }
 
     private void process(ResolutionResult artifact, Lane lane) {
         LOG.info("Processing {} ...", artifact.coordinate);

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -42,6 +42,7 @@ import eu.f4sten.pomanalyzer.utils.EffectiveModelBuilder;
 import eu.f4sten.pomanalyzer.utils.MavenRepositoryUtils;
 import eu.f4sten.pomanalyzer.utils.PackagingFixer;
 import eu.f4sten.pomanalyzer.utils.PomExtractor;
+import eu.f4sten.pomanalyzer.utils.ProgressTracker;
 import eu.f4sten.pomanalyzer.utils.Resolver;
 import eu.fasten.core.maven.utils.MavenUtilities;
 
@@ -50,6 +51,7 @@ public class Main implements Plugin {
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
     private static final int EXEC_DELAY_MS = 1000;
 
+    private final ProgressTracker tracker;
     private final MavenRepositoryUtils repo;
     private final EffectiveModelBuilder modelBuilder;
     private final PomExtractor extractor;
@@ -66,8 +68,10 @@ public class Main implements Plugin {
     private MavenId curId;
 
     @Inject
-    public Main(MavenRepositoryUtils repo, EffectiveModelBuilder modelBuilder, PomExtractor extractor, DatabaseUtils db,
-            Resolver resolver, Kafka kafka, PomAnalyzerArgs args, MessageGenerator msgs, PackagingFixer fixer) {
+    public Main(ProgressTracker tracker, MavenRepositoryUtils repo, EffectiveModelBuilder modelBuilder,
+            PomExtractor extractor, DatabaseUtils db, Resolver resolver, Kafka kafka, PomAnalyzerArgs args,
+            MessageGenerator msgs, PackagingFixer fixer) {
+        this.tracker = tracker;
         this.repo = repo;
         this.modelBuilder = modelBuilder;
         this.extractor = extractor;

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -47,6 +47,7 @@ import eu.fasten.core.utils.Asserts;
 public class Main implements Plugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+    private static final int EXEC_DELAY_MS = 2000;
 
     private final MavenRepositoryUtils repo;
     private final EffectiveModelBuilder modelBuilder;
@@ -142,6 +143,7 @@ public class Main implements Plugin {
             return;
         }
         LOG.info("Processing {} ...", artifact.coordinate);
+        delayExecutionToPreventThrottling();
 
         var consumedAt = new Date();
         kafka.sendHeartbeat();
@@ -202,5 +204,13 @@ public class Main implements Plugin {
         return lane == Lane.NORMAL
                 ? db.hasPackageBeenIngested(coordinate, NORMAL) || db.hasPackageBeenIngested(coordinate, PRIORITY)
                 : db.hasPackageBeenIngested(coordinate, lane);
+    }
+
+    private static void delayExecutionToPreventThrottling() {
+        try {
+            Thread.sleep(EXEC_DELAY_MS);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -19,6 +19,7 @@ import static eu.f4sten.infra.kafka.Lane.NORMAL;
 import static eu.f4sten.infra.kafka.Lane.PRIORITY;
 import static java.lang.String.format;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -59,7 +60,9 @@ public class Main implements Plugin {
     private final MessageGenerator msgs;
     private final PackagingFixer fixer;
 
+    private final Date startedAt = new Date();
     private final Set<String> ingested = new HashSet<>();
+
     private MavenId curId;
 
     @Inject
@@ -134,7 +137,9 @@ public class Main implements Plugin {
     }
 
     private void process(ResolutionResult artifact, Lane lane) {
-        LOG.info("Processing {} ...  (dependency of: {})", artifact.coordinate, curId.asCoordinate());
+        var duration = Duration.between(startedAt.toInstant(), new Date().toInstant());
+        var msg = "Processing {} ... (dependency of: {}, started at: {}, duration: {})";
+        LOG.info(msg, artifact.coordinate, curId.asCoordinate(), startedAt, duration);
 
         delayExecutionToPreventThrottling();
 

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -48,7 +48,7 @@ import eu.fasten.core.utils.Asserts;
 public class Main implements Plugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
-    private static final int EXEC_DELAY_MS = 2000;
+    private static final int EXEC_DELAY_MS = 1000;
 
     private final MavenRepositoryUtils repo;
     private final EffectiveModelBuilder modelBuilder;

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -43,7 +43,6 @@ import eu.f4sten.pomanalyzer.utils.PackagingFixer;
 import eu.f4sten.pomanalyzer.utils.PomExtractor;
 import eu.f4sten.pomanalyzer.utils.Resolver;
 import eu.fasten.core.maven.utils.MavenUtilities;
-import eu.fasten.core.utils.Asserts;
 
 public class Main implements Plugin {
 
@@ -134,10 +133,9 @@ public class Main implements Plugin {
         return new ResolutionResult(id.asCoordinate(), artifactRepository);
     }
 
-
-
     private void process(ResolutionResult artifact, Lane lane) {
-        LOG.info("Processing {} ...", artifact.coordinate);
+        LOG.info("Processing {} ...  (dependency of: {})", artifact.coordinate, curId.asCoordinate());
+
         delayExecutionToPreventThrottling();
 
         var consumedAt = new Date();

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -107,17 +107,17 @@ public class Main implements Plugin {
                 return;
             }
             r.run();
-        } catch (Throwable t) {
+        } catch (Exception e) {
             // if execution crashes, prevent re-try for both lanes
             memMarkAsIngestedPackage(artifact.coordinate, NORMAL);
             memMarkAsIngestedPackage(artifact.coordinate, PRIORITY);
 
-            LOG.warn("Execution failed for (original) input: {}", curId, t);
+            LOG.warn("Execution failed for (original) input: {}", curId, e);
 
-            boolean isRuntimeExceptionAndNoSubtype = RuntimeException.class.equals(t.getClass());
-            boolean isWrapped = isRuntimeExceptionAndNoSubtype && t.getCause() != null;
+            boolean isRuntimeExceptionAndNoSubtype = RuntimeException.class.equals(e.getClass());
+            boolean isWrapped = isRuntimeExceptionAndNoSubtype && e.getCause() != null;
 
-            var msg = msgs.getErr(curId, isWrapped ? t.getCause() : t);
+            var msg = msgs.getErr(curId, isWrapped ? e.getCause() : e);
             kafka.publish(msg, args.kafkaOut, Lane.ERROR);
         }
     }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -91,10 +91,7 @@ public class Main implements Plugin {
             LOG.debug("{}", id);
             var artifact = bootstrapFirstResolutionResultFromInput(id);
             runAndCatch(artifact, lane, () -> {
-                if (!artifact.localPomFile.exists()) {
-                    LOG.info("Downloading POM file ...");
-                    artifact.localPomFile = repo.downloadPomToTemp(artifact);
-                }
+                resolver.resolveIfNotExisting(artifact);
                 process(artifact, lane);
             });
         });

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/PomAnalyzerInjectorConfig.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/PomAnalyzerInjectorConfig.java
@@ -15,8 +15,6 @@
  */
 package eu.f4sten.pomanalyzer;
 
-import static eu.f4sten.infra.kafka.Lane.PRIORITY;
-
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 
@@ -32,7 +30,6 @@ import eu.f4sten.infra.utils.PostgresConnector;
 import eu.f4sten.infra.utils.Version;
 import eu.f4sten.pomanalyzer.json.CoreJacksonModule;
 import eu.f4sten.pomanalyzer.utils.DatabaseUtils;
-import eu.f4sten.pomanalyzer.utils.Resolver;
 
 @InjectorConfig
 public class PomAnalyzerInjectorConfig implements IInjectorConfig {
@@ -53,11 +50,6 @@ public class PomAnalyzerInjectorConfig implements IInjectorConfig {
         var c = pc.getNewConnection();
         var dslContext = DSL.using(c, SQLDialect.POSTGRES);
         return new DatabaseUtils(dslContext, json, version);
-    }
-
-    @Provides
-    public Resolver bindResolver(DatabaseUtils dbUtils) {
-        return new Resolver(gapv -> dbUtils.hasPackageBeenIngested(gapv, PRIORITY));
     }
 
     @ProvidesIntoSet

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/MavenId.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/MavenId.java
@@ -42,4 +42,12 @@ public class MavenId {
     public String toString() {
         return ToStringBuilder.reflectionToString(this, MULTI_LINE_STYLE);
     }
+
+    public String asCoordinate() {
+        return String.format("%s:%s:?:%s", $(groupId), $(artifactId), $(version));
+    }
+
+    private static String $(String s) {
+        return s == null ? "?" : s;
+    }
 }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/NoArtifactRepositoryException.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/NoArtifactRepositoryException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.pomanalyzer.data;
+
+public class NoArtifactRepositoryException extends RuntimeException {
+
+    private static final long serialVersionUID = 209206110086124120L;
+
+    public NoArtifactRepositoryException(String msg) {
+        super(msg);
+    }
+
+    public NoArtifactRepositoryException(Throwable t) {
+        super(t);
+    }
+
+    public NoArtifactRepositoryException(String msg, Throwable t) {
+        super(msg, t);
+    }
+}

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/UnresolvablePomFileException.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/UnresolvablePomFileException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.pomanalyzer.data;
+
+public class UnresolvablePomFileException extends RuntimeException {
+
+    private static final long serialVersionUID = 3468844197777652099L;
+
+    public UnresolvablePomFileException(String msg) {
+        super(msg);
+    }
+
+    public UnresolvablePomFileException(Throwable t) {
+        super(t);
+    }
+
+    public UnresolvablePomFileException(String msg, Throwable t) {
+        super(msg, t);
+    }
+}

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/exceptions/ExecutionTimeoutError.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/exceptions/ExecutionTimeoutError.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.pomanalyzer.exceptions;
+
+public class ExecutionTimeoutError extends Error {
+
+    private static final long serialVersionUID = -8751727696511990784L;
+
+    public ExecutionTimeoutError(String msg) {
+        super(msg);
+    }
+
+    public ExecutionTimeoutError(Throwable t) {
+        super(t);
+    }
+
+    public ExecutionTimeoutError(String msg, Throwable t) {
+        super(msg, t);
+    }
+}

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/exceptions/NoArtifactRepositoryException.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/exceptions/NoArtifactRepositoryException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.f4sten.pomanalyzer.data;
+package eu.f4sten.pomanalyzer.exceptions;
 
 public class NoArtifactRepositoryException extends RuntimeException {
 

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/exceptions/UnresolvablePomFileException.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/exceptions/UnresolvablePomFileException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.f4sten.pomanalyzer.data;
+package eu.f4sten.pomanalyzer.exceptions;
 
 public class UnresolvablePomFileException extends RuntimeException {
 

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/DatabaseUtils.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/DatabaseUtils.java
@@ -88,14 +88,17 @@ public class DatabaseUtils {
 
     public void markAsIngestedPackage(String gapv, Lane lane) {
         if (!hasPackageBeenIngested(gapv, lane)) {
-            var key = String.format("%s-%s", gapv, lane);
             var dao = getDao(context);
-            dao.insertIngestedArtifact(key, version.get());
+            dao.insertIngestedArtifact(toKey(gapv, lane), version.get());
         }
     }
 
+    private static String toKey(String gapv, Lane lane) {
+        return String.format("%s-%s", gapv, lane);
+    }
+
     public boolean hasPackageBeenIngested(String gapv, Lane lane) {
-        var key = String.format("%s-%s", gapv, lane);
+        var key = toKey(gapv, lane);
         var dao = getDao(context);
         return dao.isArtifactIngested(key);
     }
@@ -112,5 +115,17 @@ public class DatabaseUtils {
             }
             return new Timestamp(timestamp);
         }
+    }
+
+    public int getRetryCount(String key) {
+        return getDao(context).getIngestionRetryCount(key);
+    }
+
+    public void registerRetry(String key) {
+        getDao(context).registerIngestionRetry(key);
+    }
+
+    public void pruneRetries(String key) {
+        getDao(context).pruneIngestionRetries(key);
     }
 }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/MavenRepositoryUtils.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/MavenRepositoryUtils.java
@@ -15,10 +15,6 @@
  */
 package eu.f4sten.pomanalyzer.utils;
 
-import static eu.fasten.core.utils.Asserts.assertNotNull;
-import static java.io.File.createTempFile;
-import static org.apache.commons.io.FileUtils.copyURLToFile;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -36,25 +32,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import eu.f4sten.pomanalyzer.data.PomAnalysisResult;
-import eu.f4sten.pomanalyzer.data.ResolutionResult;
 import eu.fasten.core.utils.Asserts;
 
 public class MavenRepositoryUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(MavenRepositoryUtils.class);
     private static final String[] ALLOWED_CLASSIFIERS = new String[] { null, "sources" };
-
-    public File downloadPomToTemp(ResolutionResult artifact) {
-        assertNotNull(artifact);
-        try {
-            var source = new URL(artifact.getPomUrl());
-            File target = createTempFile("pom-analyzer.", ".pom");
-            copyURLToFile(source, target);
-            return target;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     /**
      * returns url of sources jar if it exists, null otherwise
@@ -77,7 +60,7 @@ public class MavenRepositoryUtils {
             var con = url.openConnection();
             var lastModified = con.getHeaderField("Last-Modified");
             if (lastModified == null) {
-                LOG.error("cannot infer release date, 'Last-Modified' header missing in response for '{}'", url);
+                LOG.error("Cannot infer release date, 'Last-Modified' header missing in response for '{}'", url);
                 return -1;
             }
             var releaseDate = new SimpleDateFormat("E, d MMM yyyy HH:mm:ss Z", Locale.ENGLISH).parse(lastModified);
@@ -96,7 +79,7 @@ public class MavenRepositoryUtils {
         }
         Asserts.assertContains(ALLOWED_CLASSIFIERS, classifier);
         var classifierStr = classifier != null ? "-" + classifier : "";
-        if(!r.artifactRepository.endsWith("/")) {
+        if (!r.artifactRepository.endsWith("/")) {
             r.artifactRepository += "/";
         }
         var url = r.artifactRepository + r.groupId.replace('.', '/') + "/" + r.artifactId + "/" + r.version + "/"

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/ProgressTracker.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/ProgressTracker.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.pomanalyzer.utils;
+
+import static eu.f4sten.infra.kafka.Lane.NORMAL;
+import static eu.f4sten.infra.kafka.Lane.PRIORITY;
+import static java.lang.String.format;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.inject.Inject;
+
+import eu.f4sten.infra.kafka.Lane;
+import eu.f4sten.pomanalyzer.data.MavenId;
+import eu.f4sten.pomanalyzer.data.ResolutionResult;
+
+public class ProgressTracker {
+
+    private static final int MAX_RETRIES = 3;
+
+    private final Set<String> ingested = new HashSet<>();
+    private final DatabaseUtils db;
+
+    private MavenId curOriginal;
+
+    @Inject
+    public ProgressTracker(DatabaseUtils db) {
+        this.db = db;
+    }
+
+    public void startNextOriginal(MavenId original) {
+        this.curOriginal = original;
+    }
+
+    public MavenId getCurrentOriginal() {
+        return curOriginal;
+    }
+
+    public void registerRetry(ResolutionResult artifact, Lane lane) {
+        db.registerRetry(toKey(artifact.coordinate, lane));
+    }
+
+    public void pruneRetries(ResolutionResult artifact, Lane lane) {
+        db.pruneRetries(toKey(artifact.coordinate, lane));
+    }
+
+    private boolean isRetryCountExceeded(String coordinate, Lane lane) {
+        return db.getRetryCount(toKey(coordinate, lane)) > MAX_RETRIES;
+    }
+
+    public boolean shouldSkip(ResolutionResult artifact, Lane lane) {
+        var c = artifact.coordinate;
+        return existsInMemory(c, lane) || existsInDatabase(c, lane) || isRetryCountExceeded(c, lane);
+    }
+
+    public void executionCrash(ResolutionResult artifact, Lane lane) {
+        // if execution crashes, prevent re-try for both lanes
+        pruneRetries(artifact, lane);
+        markCompletionInMem(artifact.coordinate, NORMAL);
+        markCompletionInMem(artifact.coordinate, PRIORITY);
+    }
+
+    public void markCompletionInMem(String coord, Lane lane) {
+        ingested.add(toKey(coord, lane));
+    }
+
+    /* move mem-mark to DB, remove count */
+    public void markCompletionInDb(String coord, Lane lane) {
+        db.markAsIngestedPackage(coord, lane);
+        ingested.remove(toKey(coord, lane));
+    }
+
+    private boolean existsInMemory(String coordinate, Lane lane) {
+        return lane == NORMAL
+                ? ingested.contains(toKey(coordinate, NORMAL)) || ingested.contains(toKey(coordinate, PRIORITY))
+                : ingested.contains(toKey(coordinate, lane));
+    }
+
+    public boolean existsInDatabase(String coordinate, Lane lane) {
+        return lane == NORMAL
+                ? db.hasPackageBeenIngested(coordinate, NORMAL) || db.hasPackageBeenIngested(coordinate, PRIORITY)
+                : db.hasPackageBeenIngested(coordinate, lane);
+    }
+
+    private static String toKey(String coordinate, Lane lane) {
+        return format("%s-%s", coordinate, lane);
+    }
+}

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
@@ -15,7 +15,6 @@
  */
 package eu.f4sten.pomanalyzer.utils;
 
-import static java.lang.String.format;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.COMPILE;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.PROVIDED;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.RUNTIME;
@@ -30,6 +29,7 @@ import java.util.stream.Collectors;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.impl.maven.MavenResolvedArtifactImpl;
 
+import eu.f4sten.pomanalyzer.data.NoArtifactRepositoryException;
 import eu.f4sten.pomanalyzer.data.ResolutionResult;
 
 public class Resolver {
@@ -46,9 +46,7 @@ public class Resolver {
                 coordToResult.put(res.coordinate, res);
                 return;
             }
-
-            String msg = "Cannot find artifactRepository for %s.";
-            throw new IllegalStateException(format(msg, res.coordinate));
+            throw new NoArtifactRepositoryException(res.coordinate);
         });
 
         return new HashSet<>(coordToResult.values());

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
@@ -64,6 +64,7 @@ public class Resolver {
             MavenResolvedArtifactImpl.artifactRepositories = res;
             Maven.configureResolver() //
                     .withClassPathResolution(false) //
+                    .withRemoteRepo(getRepo(artifactRepository)) //
                     .loadPomFromFile(f) //
                     .importDependencies(COMPILE, RUNTIME, PROVIDED, SYSTEM) //
                     .resolve() //
@@ -104,10 +105,21 @@ public class Resolver {
         var repoName = String.format("%s.%d", Resolver.class.getName(), new Date().getTime());
         Maven.configureResolver() //
                 .withClassPathResolution(false) //
-                .withMavenCentralRepo(false) //
-                .withRemoteRepo(repoName, artifact.artifactRepository, "default") //
+                .withRemoteRepo(getRepo(artifact.artifactRepository)) //
                 .resolve(artifact.coordinate.replace("?", "pom")) //
                 .withoutTransitivity() //
                 .asResolvedArtifact();
+    }
+
+    private static MavenRemoteRepository getRepo(String url) {
+        return MavenRemoteRepositories //
+                .createRemoteRepository(getRepoName(url), url, "default") //
+                .setChecksumPolicy(MavenChecksumPolicy.CHECKSUM_POLICY_WARN) //
+                .setUpdatePolicy(MavenUpdatePolicy.UPDATE_POLICY_NEVER);
+    }
+
+    private static String getRepoName(String url) {
+        var simplifiedUrl = url.replaceAll("[^a-zA-Z0-9-]+", "");
+        return format("%s-%s", Resolver.class.getName(), simplifiedUrl);
     }
 }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
@@ -16,7 +16,6 @@
 package eu.f4sten.pomanalyzer.utils;
 
 import static java.lang.String.format;
-import static java.util.stream.IntStream.range;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.COMPILE;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.PROVIDED;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.RUNTIME;
@@ -26,75 +25,30 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.impl.maven.MavenResolvedArtifactImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import eu.f4sten.pomanalyzer.data.ResolutionResult;
 
 public class Resolver {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Resolver.class);
-
     // Attention: Be aware that the test suite for this class is disabled by default
     // to avoid unnecessary downloads on every build. Make sure to re-enable the
     // tests and run them locally for every change in this class.
 
-    private Predicate<String> funShouldSkip;
-
-    public Resolver() {
-        // by default, nothing gets skipped
-        this(s -> false);
-    }
-
-    /**
-     * @param funShouldSkip Registers a Predicate that can prevent the processing of
-     *                      a coordinate in the form gid:aid:packaging:version
-     */
-    public Resolver(Predicate<String> funShouldSkip) {
-        this.funShouldSkip = funShouldSkip;
-    }
-
     public Set<ResolutionResult> resolveDependenciesFromPom(File pom) {
         var coordToResult = new HashMap<String, ResolutionResult>();
 
-        // two iterations: 0) resolving and (potential) deletion 1) get artifactRepos
-        range(0, 2).forEach(i -> {
-            resolvePom(pom).forEach(res -> {
-                // ignore known dependencies or those that should be skipped (e.g., exist in DB)
-                if (coordToResult.containsKey(res.coordinate) || funShouldSkip.test(res.coordinate)) {
-                    return;
-                }
+        resolvePom(pom).forEach(res -> {
+            if (res.artifactRepository.startsWith("http")) {
+                coordToResult.put(res.coordinate, res);
+                return;
+            }
 
-                // remember identified artifactRepository
-                if (res.artifactRepository.startsWith("http")) {
-                    coordToResult.put(res.coordinate, res);
-                    return;
-                }
-
-                // if a package is interesting, but has already been downloaded before (i.e., it
-                // exists in the local .m2 folder, it must be deleted and re-downloaded (which
-                // automatically happens in the second iteration). Otherwise, it is impossible
-                // to infer its source artifact repository.
-                if (i == 0) {
-                    File f = res.getLocalPackageFile();
-                    if (f.exists() && f.isFile()) {
-                        f.delete();
-                    }
-                } else {
-                    if (SystemUtils.IS_OS_WINDOWS) {
-                        LOG.error("Cannot find artifactRepository for {}.", res.coordinate);
-                    } else {
-                        String msg = "Cannot find artifactRepository for %s.";
-                        throw new IllegalStateException(format(msg, res.coordinate));
-                    }
-                }
-            });
+            String msg = "Cannot find artifactRepository for %s.";
+            throw new IllegalStateException(format(msg, res.coordinate));
         });
 
         return new HashSet<>(coordToResult.values());

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
@@ -15,26 +15,32 @@
  */
 package eu.f4sten.pomanalyzer.utils;
 
+import static java.lang.String.format;
+import static java.util.stream.IntStream.range;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.COMPILE;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.PROVIDED;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.RUNTIME;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.SYSTEM;
 
 import java.io.File;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.repository.MavenChecksumPolicy;
+import org.jboss.shrinkwrap.resolver.api.maven.repository.MavenRemoteRepositories;
+import org.jboss.shrinkwrap.resolver.api.maven.repository.MavenRemoteRepository;
+import org.jboss.shrinkwrap.resolver.api.maven.repository.MavenUpdatePolicy;
 import org.jboss.shrinkwrap.resolver.impl.maven.MavenResolvedArtifactImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import eu.f4sten.pomanalyzer.data.NoArtifactRepositoryException;
 import eu.f4sten.pomanalyzer.data.ResolutionResult;
-import eu.f4sten.pomanalyzer.data.UnresolvablePomFileException;
+import eu.f4sten.pomanalyzer.exceptions.NoArtifactRepositoryException;
+import eu.f4sten.pomanalyzer.exceptions.UnresolvablePomFileException;
 
 public class Resolver {
 
@@ -42,23 +48,48 @@ public class Resolver {
     // to avoid unnecessary downloads on every build. Make sure to re-enable the
     // tests and run them locally for every change in this class.
 
-    public static final Logger LOG = LoggerFactory.getLogger(Resolver.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Resolver.class);
 
-    public Set<ResolutionResult> resolveDependenciesFromPom(File pom) {
+    public Set<ResolutionResult> resolveDependenciesFromPom(File pom, String artifactRepository) {
         var coordToResult = new HashMap<String, ResolutionResult>();
 
-        resolvePom(pom).forEach(res -> {
-            if (res.artifactRepository.startsWith("http")) {
-                coordToResult.put(res.coordinate, res);
-                return;
-            }
-            throw new NoArtifactRepositoryException(res.coordinate);
+        // two iterations: 0) resolving and (potential) deletion 1) get artifactRepos
+        range(0, 2).forEach(i -> {
+            resolvePom(pom, artifactRepository).forEach(res -> {
+                // ignore known dependencies or those that should be skipped (e.g., exist in DB)
+                if (coordToResult.containsKey(res.coordinate)) {
+                    return;
+                }
+
+                // remember identified artifactRepository
+                if (res.artifactRepository.startsWith("http")) {
+                    coordToResult.put(res.coordinate, res);
+                    return;
+                }
+
+                // some packages lack information about the artifact repository in the .m2
+                // folder, caused byold Maven tools and FileLockExceptions in multi-threaded
+                // executions. This can be recovered through deletion and retry.
+                File f = res.getLocalPackageFile();
+                if (i == 0 && f.exists() && f.isFile()) {
+                    LOG.info("Deleting local package to enforce repository discovery on re-download: {}",
+                            res.coordinate);
+                    f.delete();
+                } else {
+                    // deletion "on-the-fly" does not work on windows
+                    if (IS_OS_WINDOWS) {
+                        LOG.error("Cannot find artifactRepository for {}.", res.coordinate);
+                    } else {
+                        throw new NoArtifactRepositoryException(res.coordinate);
+                    }
+                }
+            });
         });
 
         return new HashSet<>(coordToResult.values());
     }
 
-    private static Set<ResolutionResult> resolvePom(File f) {
+    private static Set<ResolutionResult> resolvePom(File f, String artifactRepository) {
         var res = new HashSet<String[]>();
         try {
             MavenResolvedArtifactImpl.artifactRepositories = res;
@@ -102,7 +133,6 @@ public class Resolver {
     }
 
     private void resolvePom(ResolutionResult artifact) {
-        var repoName = String.format("%s.%d", Resolver.class.getName(), new Date().getTime());
         Maven.configureResolver() //
                 .withClassPathResolution(false) //
                 .withRemoteRepo(getRepo(artifact.artifactRepository)) //

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/MainTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/MainTest.java
@@ -32,6 +32,7 @@ import eu.f4sten.pomanalyzer.utils.EffectiveModelBuilder;
 import eu.f4sten.pomanalyzer.utils.MavenRepositoryUtils;
 import eu.f4sten.pomanalyzer.utils.PackagingFixer;
 import eu.f4sten.pomanalyzer.utils.PomExtractor;
+import eu.f4sten.pomanalyzer.utils.ProgressTracker;
 import eu.f4sten.pomanalyzer.utils.Resolver;
 
 public class MainTest {
@@ -47,9 +48,11 @@ public class MainTest {
     private PackagingFixer fixer;
 
     private Main sut;
+    private ProgressTracker tracker;
 
     @BeforeEach
     public void setup() {
+        tracker = mock(ProgressTracker.class);
         repo = mock(MavenRepositoryUtils.class);
         modelBuilder = mock(EffectiveModelBuilder.class);
         extractor = mock(PomExtractor.class);
@@ -60,7 +63,7 @@ public class MainTest {
         msgs = mock(MessageGenerator.class);
         fixer = mock(PackagingFixer.class);
 
-        sut = new Main(repo, modelBuilder, extractor, db, resolver, kafka, args, msgs, fixer);
+        sut = new Main(tracker, repo, modelBuilder, extractor, db, resolver, kafka, args, msgs, fixer);
 
         when(extractor.process(eq(null))).thenReturn(new PomAnalysisResult());
         when(extractor.process(any(Model.class))).thenReturn(new PomAnalysisResult());
@@ -68,7 +71,7 @@ public class MainTest {
     }
 
     @Test
-    public void asd() {
+    public void basicSmokeTest() {
         sut.hashCode();
         // sut.consume("{\"groupId\":\"log4j\",\"artifactId\":\"log4j\",\"version\":\"1.2.17\"}",
         // NORMAL);

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/data/MavenIdTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/data/MavenIdTest.java
@@ -93,6 +93,20 @@ public class MavenIdTest {
         assertTrue(actual.contains("artifactRepository"));
     }
 
+    @Test
+    public void toCoordinateDefault() {
+        var actual = new MavenId().asCoordinate();
+        var expected = "?:?:?:?";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toCoordinateWithValues() {
+        var actual = someId().asCoordinate();
+        var expected = "g:a:?:v";
+        assertEquals(expected, actual);
+    }
+
     private MavenId someId() {
         var id = new MavenId();
         id.groupId = "g";

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/data/ResolutionResultTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/data/ResolutionResultTest.java
@@ -16,8 +16,8 @@
 package eu.f4sten.pomanalyzer.data;
 
 import static eu.f4sten.pomanalyzer.utils.MavenRepositoryUtils.getPathOfLocalRepository;
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,106 +25,69 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
+import java.security.InvalidParameterException;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
 
 import eu.f4sten.pomanalyzer.utils.MavenRepositoryUtils;
 
 public class ResolutionResultTest {
 
+    private static final String SOME_REPO = "http://somewhere/";
+
     @Test
     public void initStoresValuesAndDerivesPom() {
         var gapv = "g:a:jar:1";
-        var repo = "http://somewhere/";
-        var sut = new ResolutionResult(gapv, repo, inM2("...", "xyz.jar"));
+        var sut = new ResolutionResult(gapv, SOME_REPO);
 
         assertEquals(gapv, sut.coordinate);
-        assertEquals(repo, sut.artifactRepository);
+        assertEquals(SOME_REPO, sut.artifactRepository);
         assertEquals(getPathOfLocalRepository(), sut.localM2Repository);
-        assertEquals(inM2("...", "xyz.pom"), sut.localPomFile);
-        assertEquals(inM2("...", "xyz.jar"), sut.getLocalPackageFile());
+        assertEquals(inM2("g", "a", "1", "a-1.pom"), sut.localPomFile);
+        assertEquals(inM2("g", "a", "1", "a-1.jar"), sut.getLocalPackageFile());
     }
 
     @Test
-    public void localM2RepositoryCanBeReplaced() throws MalformedURLException {
-        var sut = new ResolutionResult("g:a:jar:1", "http://somewhere/", inTmp("...", "xyz.jar")) {
-            @Override
-            protected File getLocalM2Repository() {
-                return inTmp();
-            }
-        };
-        assertEquals(inTmp(), sut.localM2Repository);
-        assertEquals("http://somewhere/.../xyz.pom", sut.getPomUrl());
+    public void validationOnInitWorks() {
+        // ok
+        new ResolutionResult("g:a:jar:1", SOME_REPO);
+        new ResolutionResult("g:a:?:1", SOME_REPO);
+        // fail
+        assertInvalidParameter("g:a:1");
+        assertInvalidParameter("g:a:jar:1:sources");
+        for (var inv : new String[] { "", "?" }) {
+            assertInvalidParameter(format("%s:a:jar:1", inv));
+            assertInvalidParameter(format("g:%s:jar:1", inv));
+            assertInvalidParameter(format("g:a:jar:%s", inv));
+        }
+        assertInvalidParameter("g:a::1");
+    }
+
+    private static void assertInvalidParameter(String gapv) {
+        assertThrows(InvalidParameterException.class, () -> new ResolutionResult(gapv, SOME_REPO));
     }
 
     @Test
-    public void canBeInitializedWithoutLocalFile() throws MalformedURLException {
+    public void initializesCorrectPaths() throws MalformedURLException {
         var gapv = "g.g2:a:?:1";
-        var repo = "http://somewhere/";
-        var sut = new ResolutionResult(gapv, repo);
+        var sut = new ResolutionResult(gapv, SOME_REPO);
 
         assertEquals(inM2("g", "g2", "a", "1", "a-1.pom"), sut.localPomFile);
-        assertEquals("http://somewhere/g/g2/a/1/a-1.pom", sut.getPomUrl());
-    }
-
-    @Test
-    public void canGeneratePomUrl() throws MalformedURLException {
-        var sut = new ResolutionResult("g:a:jar:1", "http://somewhere/sub/", inM2("...", "xyz.jar"));
-        assertEquals("http://somewhere/sub/.../xyz.pom", sut.getPomUrl());
-    }
-
-    @Test
-    public void canGeneratePomUrlWithoutDoubleSlashes() throws MalformedURLException {
-
-        for (var m2 : getOSDependentM2FoldersWithAndWithoutEndingFileDelimiter()) {
-            // use repos +/- ending file delimiter and +/- subfolder
-            for (var repo : new String[] { "http://a", "http://b/", "http://c/d", "http://c/e" }) {
-                var sut = new ResolutionResult("g1.g2:a:jar:1", repo) {
-                    @Override
-                    protected File getLocalM2Repository() {
-                        return new File(m2);
-                    }
-                };
-
-                String actual = sut.getPomUrl();
-                assertTrue(actual.startsWith("http://"));
-                actual = actual.substring("http://".length());
-                assertFalse(actual.contains("//"));
-                assertTrue(actual.endsWith("/g1/g2/a/1/a-1.pom"));
-            }
-        }
-    }
-
-    private String[] getOSDependentM2FoldersWithAndWithoutEndingFileDelimiter() {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            return new String[] { "C:\\.m2", "C:\\.m2\\" };
-        }
-        return new String[] { "/.m2", "/.m2/" };
-    }
-
-    @Test
-    public void failsWhenPomIsNotInM2Folder() {
-        var sut = new ResolutionResult("g:a:jar:1", "http://somewhere/sub/", inTmp("...", "xyz.jar"));
-        assertThrows(IllegalStateException.class, () -> {
-            sut.getPomUrl();
-        });
     }
 
     @Test
     public void equality() {
-        var a = new ResolutionResult("g:a:jar:1", "http://somewhere/", inM2("...", "xyz.jar"));
-        var b = new ResolutionResult("g:a:jar:1", "http://somewhere/", inM2("...", "xyz.jar"));
+        var a = new ResolutionResult("g:a:jar:1", SOME_REPO);
+        var b = new ResolutionResult("g:a:jar:1", SOME_REPO);
         assertEquals(a, b);
         assertEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void equalityDiffGAV() {
-        var repository = "http://somewhere/";
-        var pkg = inM2("...", "xyz.jar");
-        var a = new ResolutionResult("g:a:jar:1", repository, pkg);
-        var b = new ResolutionResult("g:b:jar:1", repository, pkg);
+        var repository = SOME_REPO;
+        var a = new ResolutionResult("g:a:jar:1", repository);
+        var b = new ResolutionResult("g:b:jar:1", repository);
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
     }
@@ -132,26 +95,15 @@ public class ResolutionResultTest {
     @Test
     public void equalityDiffRepo() {
         var gapv = "g:a:jar:1";
-        var pkg = inM2("...", "xyz.jar");
-        var a = new ResolutionResult(gapv, "http://somewhere/", pkg);
-        var b = new ResolutionResult(gapv, "http://elsewhere/", pkg);
-        assertNotEquals(a, b);
-        assertNotEquals(a.hashCode(), b.hashCode());
-    }
-
-    @Test
-    public void equalityDifFile() {
-        var gapv = "g:a:jar:1";
-        var repository = "http://somewhere/";
-        var a = new ResolutionResult(gapv, repository, inM2("...", "xyz.jar"));
-        var b = new ResolutionResult(gapv, repository, inM2("...", "abc.jar"));
+        var a = new ResolutionResult(gapv, SOME_REPO);
+        var b = new ResolutionResult(gapv, "http://elsewhere/");
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void hasToStringImpl() {
-        var actual = new ResolutionResult("g:a:jar:1", "http://somewhere/", inM2("...", "xyz.jar")).toString();
+        var actual = new ResolutionResult("g:a:jar:1", SOME_REPO).toString();
         assertTrue(actual.contains("\n"));
         var l1 = actual.split("\n")[0];
         assertTrue(l1.contains(ResolutionResult.class.getSimpleName()));
@@ -162,10 +114,5 @@ public class ResolutionResultTest {
     private static File inM2(String... pathToFilename) {
         var m2 = MavenRepositoryUtils.getPathOfLocalRepository().getAbsolutePath();
         return Path.of(m2, pathToFilename).toFile();
-    }
-
-    private static File inTmp(String... pathToFilename) {
-        var tmp = System.getProperty("java.io.tmpdir");
-        return Path.of(tmp, pathToFilename).toFile();
     }
 }

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/EffectiveModelBuilderTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/EffectiveModelBuilderTest.java
@@ -35,6 +35,7 @@ import org.jboss.shrinkwrap.resolver.impl.maven.logging.LogTransferListener;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import eu.fasten.core.maven.utils.MavenUtilities;
 import eu.fasten.core.utils.TestUtils;
 
 public class EffectiveModelBuilderTest {
@@ -118,7 +119,7 @@ public class EffectiveModelBuilderTest {
         var fullPath = Path.of(EffectiveModelBuilderTest.class.getSimpleName(), pathToPom);
         File pom = TestUtils.getTestResource(fullPath.toString());
         // resolve once to make sure all dependencies exist in local repo
-        new Resolver().resolveDependenciesFromPom(pom);
+        new Resolver().resolveDependenciesFromPom(pom, MavenUtilities.MAVEN_CENTRAL_REPO);
         var sut = new EffectiveModelBuilder();
         return sut.buildEffectiveModel(pom);
     }

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ProgressTrackerTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ProgressTrackerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.pomanalyzer.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import eu.f4sten.infra.kafka.Lane;
+import eu.f4sten.pomanalyzer.data.MavenId;
+import eu.f4sten.pomanalyzer.data.ResolutionResult;
+
+public class ProgressTrackerTest {
+
+    private static final ResolutionResult SOME_RESULT = new ResolutionResult("g:a:p:v", "http://repo.org/");
+
+    private DatabaseUtils db;
+    private ProgressTracker sut;
+
+    @BeforeEach
+    public void setup() {
+        db = mockDatabase();
+        sut = new ProgressTracker(db);
+    }
+
+    private static DatabaseUtils mockDatabase() {
+        var db = mock(DatabaseUtils.class);
+        var counts = new HashMap<Object, Integer>();
+        doAnswer(inv -> {
+            var key = inv.getArgument(0);
+            counts.remove(key);
+            return null;
+        }).when(db).pruneRetries(anyString());
+        doAnswer(inv -> {
+            var key = inv.getArgument(0);
+            if (counts.containsKey(key)) {
+                counts.put(key, counts.get(key) + 1);
+            } else {
+                counts.put(key, 1);
+            }
+            return null;
+        }).when(db).registerRetry(anyString());
+        when(db.getRetryCount(anyString())).thenAnswer(inv -> {
+            var key = inv.getArgument(0);
+            return counts.get(key);
+        });
+        return db;
+    }
+
+    @Test
+    public void getOriginalDefault() {
+        assertNull(sut.getCurrentOriginal());
+    }
+
+    @Test
+    public void originalCanBeSet() {
+        var id = mock(MavenId.class);
+        sut.startNextOriginal(id);
+        assertEquals(id, sut.getCurrentOriginal());
+    }
+
+    @Test
+    public void crashesPruneCountInDb() {
+        sut.executionCrash(SOME_RESULT, Lane.NORMAL);
+        verify(db).pruneRetries("g:a:p:v-NORMAL");
+    }
+
+    @Test
+    public void crashesMarkProgressInMem() {
+        assertFalse(sut.shouldSkip(SOME_RESULT, Lane.NORMAL));
+        sut.executionCrash(SOME_RESULT, Lane.NORMAL);
+        assertTrue(sut.shouldSkip(SOME_RESULT, Lane.NORMAL));
+    }
+
+    @Test
+    public void threeRetries() {
+        assertFalse(sut.shouldSkip(SOME_RESULT, Lane.NORMAL));
+        sut.registerRetry(SOME_RESULT, Lane.NORMAL); // 1
+        assertFalse(sut.shouldSkip(SOME_RESULT, Lane.NORMAL));
+        sut.registerRetry(SOME_RESULT, Lane.NORMAL); // 2
+        assertFalse(sut.shouldSkip(SOME_RESULT, Lane.NORMAL));
+        sut.registerRetry(SOME_RESULT, Lane.NORMAL); // 3
+        assertFalse(sut.shouldSkip(SOME_RESULT, Lane.NORMAL));
+        sut.registerRetry(SOME_RESULT, Lane.NORMAL); // 4
+        assertTrue(sut.shouldSkip(SOME_RESULT, Lane.NORMAL));
+    }
+
+    // TODO add more tests
+}

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
@@ -15,6 +15,7 @@
  */
 package eu.f4sten.pomanalyzer.utils;
 
+import static eu.fasten.core.maven.utils.MavenUtilities.MAVEN_CENTRAL_REPO;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -203,6 +204,6 @@ public class ResolverTest {
     private Set<ResolutionResult> resolveTestPom(String pathToPom) {
         var fullPath = Path.of(ResolverTest.class.getSimpleName(), pathToPom);
         File pom = TestUtils.getTestResource(fullPath.toString());
-        return sut.resolveDependenciesFromPom(pom);
+        return sut.resolveDependenciesFromPom(pom, MAVEN_CENTRAL_REPO);
     }
 }

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
@@ -46,13 +46,11 @@ public class ResolverTest {
         fail("Suite is expensive and should only be run locally. Re-enable @Disabled annotation.");
     }
 
-    private Set<String> db;
     private Resolver sut;
 
     @BeforeEach
     public void setup() {
-        db = new HashSet<>();
-        sut = new Resolver(dep -> db.contains(dep));
+        sut = new Resolver();
     }
 
     @Test
@@ -72,23 +70,6 @@ public class ResolverTest {
         var expected = new HashSet<ResolutionResult>();
         expected.add(JSR305);
         expected.add(COMMONS_LANG3);
-        expected.add(REMLA);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void defaultConfigAddsEverything() {
-        sut = new Resolver();
-        resolveDirectDependencies();
-    }
-
-    @Test
-    public void ignoresExistingPackages() {
-        db.add(COMMONS_LANG3.coordinate);
-        var actual = resolveTestPom("basic.pom");
-        var expected = new HashSet<ResolutionResult>();
-        expected.add(JSR305);
         expected.add(REMLA);
 
         assertEquals(expected, actual);

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>eu.fasten</groupId>
             <artifactId>core</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>

--- a/test-utils/src/main/java/eu/f4sten/test/AssertArgsUtils.java
+++ b/test-utils/src/main/java/eu/f4sten/test/AssertArgsUtils.java
@@ -15,7 +15,8 @@
  */
 package eu.f4sten.test;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.stefanbirkner.systemlambda.Statement;
@@ -31,7 +32,12 @@ public class AssertArgsUtils {
     public static void assertArgsValidation(String expectedHint, Statement s) {
         try {
             var out = SystemLambda.tapSystemOut(() -> {
-                catchSystemExit(s);
+                var e = assertThrows(Error.class, () -> {
+                    s.execute();
+                });
+                // type unreachable, so testing for name
+                boolean isAssertArgsError = "AssertArgsError".equals((e.getClass().getSimpleName()));
+                assertTrue(isAssertArgsError);
             });
 
             boolean hasBasicParts = out.contains(TEXT_ERROR_INTRO) //


### PR DESCRIPTION
To tackle the on-going slow-down in the processing pipeline, I have provided several improvements:

- Add execution delay to PomAnalyzer to prevent download throttling
- Revise duplication detection in PomAnalyzer (also cover lanes and crashes)
- Extend Kafka ConsumerConfig (max poll interval, session timeout, client id)
- Simplify resolution logic in Resolver to prevent local deletion/re-download
- Potential fix for our Kafka rebalancing issues: Make Lane part of consumer groupId
- Revised POM file resolution to prevent unnecessary downloads
- Generally simplified the logging output from the Loader to make it easier to follow
- Revise error handling in Loader
- Add execution timeout to PomAnalyzer
- Revise Kafka logic
- Factor out progress tracking to separate class
- Introduce retry logic for PomAnalyzer