### PR TITLE
Add extensible JAX-RS server to loader infrastructure

### DIFF
--- a/infrastructure/infrastructure-impl/pom.xml
+++ b/infrastructure/infrastructure-impl/pom.xml
@@ -40,5 +40,45 @@
             <artifactId>kafka-clients</artifactId>
             <version>3.1.0</version>
         </dependency>
+
+        <!--Jetty app server -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>11.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>11.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>11.0.8</version>
+        </dependency>
+
+        <!-- Jersey JAX-RS-->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraArgs.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraArgs.java
@@ -35,4 +35,10 @@ public class InfraArgs {
 
     @Parameter(names = "--instanceId", arity = 1, description = "uniquely identifies this application instance across re-starts")
     public String instanceId = null;
+
+    @Parameter(names = "--http.port", arity = 1, description = "port used for http server")
+    public int httpPort = 8080;
+
+    @Parameter(names = "--http.baseUrl", arity = 1, description = "base url of http servlets")
+    public String httpBaseUrl = "/";
 }

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraConfig.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraConfig.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.inject.Binder;
+import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.ProvidesIntoSet;
@@ -33,6 +34,9 @@ import com.google.inject.multibindings.ProvidesIntoSet;
 import eu.f4sten.infra.IInjectorConfig;
 import eu.f4sten.infra.InjectorConfig;
 import eu.f4sten.infra.LoaderConfig;
+import eu.f4sten.infra.http.HttpServer;
+import eu.f4sten.infra.impl.http.HttpServerGracefulShutdownThread;
+import eu.f4sten.infra.impl.http.HttpServerImpl;
 import eu.f4sten.infra.impl.json.JsonUtilsImpl;
 import eu.f4sten.infra.impl.kafka.KafkaConnector;
 import eu.f4sten.infra.impl.kafka.KafkaGracefulShutdownThread;
@@ -68,6 +72,13 @@ public class InfraConfig implements IInjectorConfig {
         binder.bind(HostName.class).to(HostNameImpl.class);
         binder.bind(Version.class).to(VersionImpl.class);
         binder.bind(MessageGenerator.class).to(MessageGeneratorImpl.class);
+    }
+
+    @Provides
+    public HttpServer bindHttpServer(Injector injector) {
+        var server = new HttpServerImpl(injector, args);
+        Runtime.getRuntime().addShutdownHook(new HttpServerGracefulShutdownThread(server));
+        return server;
     }
 
     @Provides

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerConfig.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerConfig.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.http;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.glassfish.jersey.server.ResourceConfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Injector;
+
+import eu.f4sten.infra.http.Scope;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.ext.ContextResolver;
+
+public class HttpServerConfig extends ResourceConfig {
+
+    private static final Map<Scope, Class<? extends Annotation>> SCOPE_ANNOTATIONS = new HashMap<>();
+
+    {
+        SCOPE_ANNOTATIONS.put(Scope.PROTOTYPE, PerLookup.class);
+        SCOPE_ANNOTATIONS.put(Scope.REQUEST, RequestScoped.class);
+        SCOPE_ANNOTATIONS.put(Scope.SINGLETON, Singleton.class);
+    }
+
+    public HttpServerConfig(Injector injector, Map<Class<?>, Scope> bindings) {
+
+        // register global ObjectMapper
+        var om = injector.getInstance(ObjectMapper.class);
+        register(new ObjectMapperProvider(om));
+
+        // register all resources
+        for (var type : bindings.keySet()) {
+            register(type);
+        }
+
+        // register factory for all resources
+        register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                for (var type : bindings.keySet()) {
+                    var scope = bindings.get(type);
+                    var factory = new ServiceFactory<>(injector, type);
+                    bindFactory(factory).to(type).in(SCOPE_ANNOTATIONS.get(scope));
+                }
+            }
+        });
+    }
+
+    private static class ServiceFactory<T> implements Supplier<T> {
+
+        private Injector injector;
+        private Class<T> type;
+
+        private ServiceFactory(Injector injector, Class<T> type) {
+            this.injector = injector;
+            this.type = type;
+        }
+
+        @Override
+        public T get() {
+            return injector.getInstance(type);
+        }
+    }
+
+    private static class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
+
+        private final ObjectMapper om;
+
+        private ObjectMapperProvider(ObjectMapper om) {
+            this.om = om;
+        }
+
+        @Override()
+        public ObjectMapper getContext(final Class<?> type) {
+            return om;
+        }
+    }
+}

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerGracefulShutdownThread.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerGracefulShutdownThread.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.f4sten.infra.http.HttpServer;
+
+public class HttpServerGracefulShutdownThread extends Thread {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpServerGracefulShutdownThread.class);
+
+    private HttpServer server;
+
+    public HttpServerGracefulShutdownThread(HttpServer server) {
+        this.server = server;
+    }
+
+    @Override
+    public void run() {
+        LOG.info("Gracefully stopping HTTP server ...");
+        server.stop();
+    }
+}

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerImpl.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerImpl.java
@@ -85,6 +85,10 @@ public class HttpServerImpl implements HttpServer {
         }
     }
 
+    public boolean isStarting() {
+        return server.isStarting();
+    }
+
     @Override
     public void stop() {
         LOG.info("Stopping HTTP Server ...");

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerImpl.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/http/HttpServerImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.http;
+
+import static eu.f4sten.infra.http.Scope.SINGLETON;
+import static org.eclipse.jetty.servlet.ServletContextHandler.NO_SESSIONS;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+import eu.f4sten.infra.http.HttpServer;
+import eu.f4sten.infra.http.Scope;
+import eu.f4sten.infra.impl.InfraArgs;
+
+public class HttpServerImpl implements HttpServer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpServerImpl.class);
+
+    private final Injector injector;
+    private final InfraArgs args;
+    private final Server server;
+
+    private final Map<Class<?>, Scope> bindings = new HashMap<>();
+
+    @Inject
+    public HttpServerImpl(Injector injector, InfraArgs args) {
+        this.injector = injector;
+        this.args = args;
+        server = new Server(args.httpPort);
+    }
+
+    @Override
+    public void register(Class<?>... types) {
+        register(SINGLETON, types);
+    }
+
+    @Override
+    public void register(Scope scope, Class<?>... types) {
+        for (var type : types) {
+            bindings.put(type, scope);
+        }
+    }
+
+    @Override
+    public void start() {
+        LOG.info("Starting HTTP Server ...");
+
+        var config = new HttpServerConfig(injector, bindings);
+
+        var ctx = new ServletContextHandler(NO_SESSIONS);
+        ctx.setContextPath(args.httpBaseUrl);
+        ctx.addServlet(new ServletHolder(new ServletContainer(config)), "/*");
+
+        server.setHandler(ctx);
+
+        try {
+            server.start();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        LOG.info("Stopping HTTP Server ...");
+        try {
+            if (server != null && server.isRunning()) {
+                server.stop();
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/http/HttpServerGracefulShutdownThreadTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/http/HttpServerGracefulShutdownThreadTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.http;
+
+import static eu.f4sten.test.TestLoggerUtils.assertLogsContain;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import eu.f4sten.infra.http.HttpServer;
+import eu.f4sten.test.TestLoggerUtils;
+
+public class HttpServerGracefulShutdownThreadTest {
+
+    private HttpServer server;
+    private HttpServerGracefulShutdownThread sut;
+
+    @BeforeEach
+    public void setup() {
+        server = mock(HttpServer.class);
+        sut = new HttpServerGracefulShutdownThread(server);
+        TestLoggerUtils.clearLog();
+    }
+
+    @Test
+    public void serverIsStopped() {
+        sut.run();
+        verify(server).stop();
+    }
+
+    @Test
+    public void stoppingIsLogged() {
+        sut.run();
+        assertLogsContain(HttpServerGracefulShutdownThread.class, "INFO Gracefully stopping HTTP server ...");
+    }
+}

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/http/HttpServerImplTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/http/HttpServerImplTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.impl.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.inject.Injector;
+
+import eu.f4sten.infra.http.Scope;
+import eu.f4sten.infra.impl.InfraArgs;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+public class HttpServerImplTest {
+
+    private static final String SERVER_URL = "http://localhost:8080";
+
+    private Injector injector;
+    private InfraArgs args;
+    private HttpServerImpl sut;
+    private TestResource test;
+    private ObjectMapper om;
+
+    @BeforeEach
+    public void setup() {
+        args = new InfraArgs();
+        injector = mock(Injector.class);
+        sut = new HttpServerImpl(injector, args);
+
+        om = JsonMapper.builder().build().registerModule(new TestModule());
+        when(injector.getInstance(ObjectMapper.class)).thenReturn(om);
+
+        test = null;
+        when(injector.getInstance(TestResource.class)).thenAnswer(new Answer<TestResource>() {
+            @Override
+            public TestResource answer(InvocationOnMock invocation) throws Throwable {
+                test = new TestResource();
+                return test;
+            }
+        });
+    }
+
+    @AfterEach
+    public void teardown() {
+        sut.stop();
+    }
+
+    @Test
+    public void scopeDefaultIsSingleton() {
+        sut.register(TestResource.class);
+        startAndWait(sut);
+        get("/");
+        get("/");
+        assertEquals(2, test.counter);
+        verify(injector, times(1)).getInstance(TestResource.class);
+    }
+
+    @Test
+    public void scopeSingleton() {
+        sut.register(Scope.SINGLETON, TestResource.class);
+        startAndWait(sut);
+        get("/");
+        get("/");
+        assertEquals(2, test.counter);
+        verify(injector, times(1)).getInstance(TestResource.class);
+    }
+
+    @Test
+    public void scopePrototype() {
+        sut.register(Scope.PROTOTYPE, TestResource.class);
+        startAndWait(sut);
+        get("/");
+        get("/");
+        assertEquals(1, test.counter);
+        verify(injector, times(2)).getInstance(TestResource.class);
+    }
+
+    @Test
+    public void objectMapperIsUsed() throws JsonProcessingException {
+        sut.register(Scope.PROTOTYPE, TestResource.class);
+        startAndWait(sut);
+        var actual = get("/json");
+        var expected = "123";
+        assertEquals(expected, actual);
+    }
+
+    private static void startAndWait(HttpServerImpl sut) {
+        sut.start();
+        while (sut.isStarting()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static String get(String path) {
+        var res = ClientBuilder.newClient(new ClientConfig()) //
+                .target(SERVER_URL) //
+                .path(path) //
+                .request(MediaType.APPLICATION_JSON) //
+                .accept(MediaType.APPLICATION_JSON) //
+                .get(Response.class);
+        return res.readEntity(String.class);
+    }
+
+    @Path("/")
+    public static class TestResource {
+
+        public int counter = 0;
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public String get() {
+            counter++;
+            return "\"ok\"";
+        }
+
+        @GET
+        @Path("/json")
+        @Produces(MediaType.APPLICATION_JSON)
+        public TestData getData() {
+            return new TestData();
+        }
+
+    }
+
+    public static class TestData {
+        public int x = 123;
+    }
+
+    private static class TestModule extends SimpleModule {
+        private static final long serialVersionUID = 1L;
+
+        private TestModule() {
+            addSerializer(TestData.class, new JsonSerializer<TestData>() {
+                @Override
+                public void serialize(TestData t, JsonGenerator gen, SerializerProvider serializers)
+                        throws IOException {
+                    gen.writeNumber(t.x);
+                }
+            });
+            addDeserializer(TestData.class, new JsonDeserializer<TestData>() {
+                @Override
+                public TestData deserialize(JsonParser p, DeserializationContext ctxt)
+                        throws IOException, JacksonException {
+                    var t = new TestData();
+                    t.x = p.getIntValue();
+                    return t;
+                }
+            });
+        }
+    }
+}

--- a/infrastructure/infrastructure/pom.xml
+++ b/infrastructure/infrastructure/pom.xml
@@ -36,5 +36,13 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+
+        <!-- required annotations for servlets (served through HttpServerImpl) -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/http/HttpServer.java
+++ b/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/http/HttpServer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.http;
+
+public interface HttpServer {
+
+    void register(Class<?>... types);
+
+    void register(Scope scope, Class<?>... types);
+
+    void start();
+
+    void stop();
+}

--- a/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/http/Scope.java
+++ b/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/http/Scope.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.infra.http;
+
+public enum Scope {
+
+    /**
+     * new instance on every look-up
+     */
+    PROTOTYPE,
+
+    /**
+     * same instance within one request
+     */
+    REQUEST,
+
+    /**
+     * singleton instance
+     */
+    SINGLETON
+}

--- a/infrastructure/loader/pom.xml
+++ b/infrastructure/loader/pom.xml
@@ -57,6 +57,11 @@
         </dependency>
         <dependency>
             <groupId>eu.fasten-project</groupId>
+            <artifactId>dependency-graph-resolver</artifactId>
+            <version>0.0.6-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.fasten-project</groupId>
             <artifactId>integration-tests</artifactId>
             <version>0.0.7-SNAPSHOT</version>
         </dependency>

--- a/infrastructure/loader/pom.xml
+++ b/infrastructure/loader/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>eu.fasten-project</groupId>
             <artifactId>dependency-graph-resolver</artifactId>
-            <version>0.0.6-SNAPSHOT</version>
+            <version>0.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>eu.fasten-project</groupId>

--- a/plugins/dependency-graph-resolver/pom.xml
+++ b/plugins/dependency-graph-resolver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>eu.fasten-project</groupId>
         <artifactId>plugins</artifactId>
-        <version>0.0.6-SNAPSHOT</version>
+        <version>0.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>dependency-graph-resolver</artifactId>
 
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>eu.fasten-project</groupId>
             <artifactId>pom-analyzer</artifactId>
-            <version>0.0.6-SNAPSHOT</version>
+            <version>0.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/plugins/dependency-graph-resolver/pom.xml
+++ b/plugins/dependency-graph-resolver/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.fasten-project</groupId>
+        <artifactId>plugins</artifactId>
+        <version>0.0.6-SNAPSHOT</version>
+    </parent>
+    <artifactId>dependency-graph-resolver</artifactId>
+
+</project>

--- a/plugins/dependency-graph-resolver/pom.xml
+++ b/plugins/dependency-graph-resolver/pom.xml
@@ -9,4 +9,12 @@
     </parent>
     <artifactId>dependency-graph-resolver</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>eu.fasten-project</groupId>
+            <artifactId>pom-analyzer</artifactId>
+            <version>0.0.6-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/DepGraphArgs.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/DepGraphArgs.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.depgraph;
+
+public class DepGraphArgs {
+    // none yet
+}

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/DepGraphConfig.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/DepGraphConfig.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.google.inject.Binder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 
+import eu.f4sten.depgraph.data.Coordinates;
 import eu.f4sten.depgraph.data.JsonSerializationModule;
 import eu.f4sten.depgraph.data.Naming;
 import eu.f4sten.infra.IInjectorConfig;
@@ -37,6 +38,7 @@ public class DepGraphConfig implements IInjectorConfig {
     public void configure(Binder binder) {
         binder.bind(DepGraphArgs.class).toInstance(args);
         binder.bind(Naming.class).toInstance(new Naming("seb"));
+        binder.bind(Coordinates.class).toInstance(new Coordinates());
     }
 
     @ProvidesIntoSet

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/DepGraphConfig.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/DepGraphConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.depgraph;
+
+import com.fasterxml.jackson.databind.Module;
+import com.google.inject.Binder;
+import com.google.inject.multibindings.ProvidesIntoSet;
+
+import eu.f4sten.depgraph.data.JsonSerializationModule;
+import eu.f4sten.depgraph.data.Naming;
+import eu.f4sten.infra.IInjectorConfig;
+import eu.f4sten.infra.InjectorConfig;
+
+@InjectorConfig
+public class DepGraphConfig implements IInjectorConfig {
+
+    private DepGraphArgs args;
+
+    public DepGraphConfig(DepGraphArgs args) {
+        this.args = args;
+    }
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(DepGraphArgs.class).toInstance(args);
+        binder.bind(Naming.class).toInstance(new Naming("seb"));
+    }
+
+    @ProvidesIntoSet
+    public Module bindModule() {
+        return new JsonSerializationModule();
+    }
+}

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/Main.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/Main.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.depgraph;
+
+import javax.inject.Inject;
+
+import eu.f4sten.depgraph.endpoints.Hello;
+import eu.f4sten.infra.Plugin;
+import eu.f4sten.infra.http.HttpServer;
+
+public class Main implements Plugin {
+
+    private HttpServer server;
+
+    @Inject
+    public Main(HttpServer server) {
+        this.server = server;
+    }
+
+    @Override
+    public void run() {
+        server.register(Hello.class);
+        server.start();
+    }
+}

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/Main.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/Main.java
@@ -17,22 +17,53 @@ package eu.f4sten.depgraph;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.f4sten.depgraph.data.Coordinates;
 import eu.f4sten.depgraph.endpoints.Hello;
 import eu.f4sten.infra.Plugin;
 import eu.f4sten.infra.http.HttpServer;
+import eu.f4sten.infra.json.TRef;
+import eu.f4sten.infra.kafka.DefaultTopics;
+import eu.f4sten.infra.kafka.Kafka;
+import eu.f4sten.infra.kafka.Message;
+import eu.f4sten.pomanalyzer.data.PomAnalysisResult;
 
 public class Main implements Plugin {
 
-    private HttpServer server;
+    private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+    private final HttpServer server;
+    private final Kafka kafka;
+    private final Coordinates coords;
 
     @Inject
-    public Main(HttpServer server) {
+    public Main(HttpServer server, Kafka kafka, Coordinates coords) {
         this.server = server;
+        this.kafka = kafka;
+        this.coords = coords;
     }
 
     @Override
     public void run() {
+
         server.register(Hello.class);
         server.start();
+
+        kafka.subscribe(DefaultTopics.POM_ANALYZER, new TRef<Message<Void, PomAnalysisResult>>() {}, (m, l) -> {
+            var res = m.payload;
+            LOG.info("Adding coordinate {} ...", res);
+            coords.processed.add(res.toCoordinate());
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        while (!Thread.interrupted()) {
+            kafka.poll();
+        }
     }
 }

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/Coordinates.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/Coordinates.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.depgraph.data;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Coordinates {
+
+    public final Set<String> processed = new HashSet<>();
+}

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/JsonSerializationModule.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/JsonSerializationModule.java
@@ -45,7 +45,8 @@ public class JsonSerializationModule extends SimpleModule {
             @Override
             public Hello deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
                 String name = p.getValueAsString();
-                return new Hello(new Naming(name));
+                // bad example, Hello is not a data structure and has dependencies
+                return new Hello(new Naming(name), null);
             }
         });
     }

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/JsonSerializationModule.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/JsonSerializationModule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.depgraph.data;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import eu.f4sten.depgraph.endpoints.Hello;
+
+public class JsonSerializationModule extends SimpleModule {
+
+    private static final long serialVersionUID = -8680812356142473495L;
+
+    public JsonSerializationModule() {
+
+        addSerializer(Hello.class, new JsonSerializer<Hello>() {
+            @Override
+            public void serialize(Hello h, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+                gen.writeString(h.name);
+            }
+        });
+
+        addDeserializer(Hello.class, new JsonDeserializer<Hello>() {
+            @Override
+            public Hello deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+                String name = p.getValueAsString();
+                return new Hello(new Naming(name));
+            }
+        });
+    }
+}

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/Naming.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/data/Naming.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.depgraph.data;
+
+public class Naming {
+
+    public final String name;
+
+    public Naming(String name) {
+        this.name = name;
+    }
+}

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/endpoints/Hello.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/endpoints/Hello.java
@@ -1,10 +1,13 @@
 package eu.f4sten.depgraph.endpoints;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import eu.f4sten.depgraph.data.Coordinates;
 import eu.f4sten.depgraph.data.Naming;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -17,9 +20,11 @@ public class Hello {
     private static final Logger LOG = LoggerFactory.getLogger(Hello.class);
 
     public final String name;
+    private final Coordinates coords;
 
     @Inject
-    public Hello(Naming n) {
+    public Hello(Naming n, Coordinates coords) {
+        this.coords = coords;
         LOG.info("init");
         this.name = n.name;
     }
@@ -40,6 +45,13 @@ public class Hello {
     @Produces(MediaType.APPLICATION_JSON)
     public Hello sayJSonHello() {
         return this;
+    }
+
+    @GET
+    @Path("/coords")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Set<String> getProcessedCoordinates() {
+        return coords.processed;
     }
 
     @GET

--- a/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/endpoints/Hello.java
+++ b/plugins/dependency-graph-resolver/src/main/java/eu/f4sten/depgraph/endpoints/Hello.java
@@ -1,0 +1,51 @@
+package eu.f4sten.depgraph.endpoints;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.f4sten.depgraph.data.Naming;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class Hello {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Hello.class);
+
+    public final String name;
+
+    @Inject
+    public Hello(Naming n) {
+        LOG.info("init");
+        this.name = n.name;
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sayPlainTextHello() {
+        return "Hello " + name + "! (plain text)";
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_XML)
+    public String sayXMLHello() {
+        return "<?xml version=\"1.0\"?>" + "<hello> Hello " + name + "! (XML)</hello>";
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Hello sayJSonHello() {
+        return this;
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public String sayHtmlHello() {
+        LOG.info("html");
+        return "<html><body>" + "Hello " + name + "! (HTML)</body></html> ";
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>eu.fasten</groupId>
             <artifactId>core</artifactId>
-            <version>0.0.2</version>
+            <version>0.0.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -14,6 +14,7 @@
         <module>maven-crawler</module>
         <module>pom-analyzer</module>
         <module>callable-indexer</module>
+        <module>dependency-graph-resolver</module>
         <module>integration-tests</module>
     </modules>
 


### PR DESCRIPTION
I have added an extensible web server to the loader infrastructure that builds the foundation for the planned micro-services. The server can be requested via the regular dependency injection mechanism. To make it possible to replace the internal HK2 injector, it was necessary to require manual resource binding (automated resource discovery is not supported) via the `register` methods, which allows to bind the resources to different scopes. Resources can be configured using the regular JAX-RS annotations.

The usage of the HTTP server is illustrated in the provided skeleton for the `dependency-graph-resolver`. The example includes endpoints for different Mime types, as well as a proof-of-concept for making Kafka related messages available through a micro-service.