### PR TITLE
Stabilize dependency order in PomAnalysisResult on iteration/serialization

### DIFF
--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/PomAnalysisResult.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/data/PomAnalysisResult.java
@@ -19,6 +19,7 @@ import static java.lang.String.format;
 import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -43,7 +44,8 @@ public class PomAnalysisResult implements Cloneable {
     public long releaseDate = -1L;
     public String projectName = null;
 
-    public final Set<Dependency> dependencies = new HashSet<>();
+    // used LinkedHashSet, because order is relevant for resolution
+    public final LinkedHashSet<Dependency> dependencies = new LinkedHashSet<>();
     public final Set<Dependency> dependencyManagement = new HashSet<>();
 
     public String repoUrl = null;


### PR DESCRIPTION
To resolve Maven dependencies ourselves, we need a stable order in the PomAnalysisResults, as the order affects the *mediation* in the resolution process. By using a simple `Set<Dependency>` we are loosing this information though. To fix this issue, I have changed the data structure to use a `LinkedHashSet<>` instead. I have also provided tests (both for simple iteration and for a serialization round-trip) to illustrate that the solution is working and to prevent a regression in the future..