### PR TITLE
Fix model build exceptions

### DIFF
--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/EffectiveModelBuilder.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/EffectiveModelBuilder.java
@@ -37,6 +37,7 @@ public class EffectiveModelBuilder {
 
             var req = new DefaultModelBuildingRequest();
             req.setProcessPlugins(false);
+            req.setSystemProperties(System.getProperties());
             req.setModelResolver(new RepositoryModelResolver(LOCAL_M2));
             req.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
             req.setPomFile(pom);

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/Resolver.java
@@ -22,6 +22,7 @@ import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.COMPILE;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.PROVIDED;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.RUNTIME;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.SYSTEM;
+import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.TEST;
 
 import java.io.File;
 import java.util.HashMap;
@@ -97,7 +98,7 @@ public class Resolver {
                     .withClassPathResolution(false) //
                     .withRemoteRepo(getRepo(artifactRepository)) //
                     .loadPomFromFile(f) //
-                    .importDependencies(COMPILE, RUNTIME, PROVIDED, SYSTEM) //
+                    .importDependencies(COMPILE, RUNTIME, PROVIDED, SYSTEM, TEST) //
                     .resolve() //
                     .withTransitivity() //
                     .asResolvedArtifact();

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/ResolverTest.java
@@ -139,20 +139,17 @@ public class ResolverTest {
     }
 
     @Test
-    public void ignoresTestAndImportScopes() {
+    public void ensureAllScopesAreIncluded() {
         var actual = resolveTestPom("scopes.pom");
         assertTrue(actual.contains(JSR305), "JSR305"); // default (none)
         assertTrue(actual.contains(SLF4J), "SLF4J"); // compile
         assertTrue(actual.contains(COMMONS_TEXT), "COMMONS_TEXT"); // runtime
         assertTrue(actual.contains(COMMONS_LANG3), "COMMONS_LANG3"); // provided
         assertTrue(actual.contains(OKIO), "OKIO"); // system
+        assertTrue(actual.contains(OPENTEST), "JUNIT"); // test
 
-        assertFalse(actual.contains(OSS_PARENT), "OSS_PARENT"); // import
-        assertFalse(actual.contains(JUNIT), "JUNIT"); // test
-
-        // direct and transitive dependencies
-        // TODO not clear where the Kotlin reference comes from?!
-        assertEquals(5 + 1, actual.size());
+        // direct deps + one (broken) system dep (not found via Maven)
+        assertEquals(6 + 1, actual.size());
     }
 
     @Test
@@ -189,12 +186,8 @@ public class ResolverTest {
             "com.squareup.okio:okio:jar:3.0.0", //
             MAVEN_CENTRAL);
 
-    private static final ResolutionResult OSS_PARENT = new ResolutionResult(//
-            "org.sonatype.oss:oss-parent:jar:2.6.3", //
-            MAVEN_CENTRAL);
-
-    private static final ResolutionResult JUNIT = new ResolutionResult(//
-            "org.junit.jupiter:junit-jupiter-api:jar:5.8.2", //
+    private static final ResolutionResult OPENTEST = new ResolutionResult(//
+            "org.opentest4j:opentest4j:jar:1.2.0", //
             MAVEN_CENTRAL);
 
     private static final ResolutionResult REMLA = new ResolutionResult(//

--- a/plugins/pom-analyzer/src/test/resources/ResolverTest/scopes.pom
+++ b/plugins/pom-analyzer/src/test/resources/ResolverTest/scopes.pom
@@ -38,17 +38,10 @@
             <systemPath>/absolute/path/to.jar</systemPath>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.8.2</version>
+            <groupId>org.opentest4j</groupId>
+            <artifactId>opentest4j</artifactId>
+            <version>1.2.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.sonatype.oss</groupId>
-            <artifactId>oss-parent</artifactId>
-            <version>9</version>
-            <type>pom</type>
-            <scope>import</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The `PomAnalyzer` is suffering from a low success rate, many coordinates fail with a `ModelBuildException`. After closer inspection, it turned out that our resolver code for Shrinkwrap did not set the system properties, which apparently is required for proper usage. This PR fixes this issue and, through this fix, substantially improves the success rate of the resolution. On top of that, this PR also adds test dependencies to the resolution scope.