### PR TITLE
Add a CLI arg to CleanUpM2Repository to accept an arbitrary path for the .m2 folder

### DIFF
--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2Repository.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2Repository.java
@@ -42,10 +42,10 @@ public class CleanUpM2Repository implements Plugin {
 
     @Override
     public void run() {
-        LOG.info("Searching for invalid pom.xml files in: {}", this.args.m2RepositoryPath);
+        LOG.info("Searching for invalid pom.xml files in: {}", args.pathM2);
 
         try {
-            Files.walkFileTree(Path.of(this.args.m2RepositoryPath), new SimpleFileVisitor<Path>() {
+            Files.walkFileTree(Path.of(args.pathM2), new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
 

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2Repository.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2Repository.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
+import com.google.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,15 +33,19 @@ import eu.f4sten.infra.Plugin;
 public class CleanUpM2Repository implements Plugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(CleanUpM2Repository.class);
+    private final CleanUpM2RepositoryArgs args;
 
-    private static final String BASE_DIR = "~/.m2/repository";
+    @Inject
+    public CleanUpM2Repository(CleanUpM2RepositoryArgs args) {
+        this.args = args;
+    }
 
     @Override
     public void run() {
-        LOG.info("Searching for invalid pom.xml files in: {}", BASE_DIR);
+        LOG.info("Searching for invalid pom.xml files in: {}", this.args.m2RepositoryPath);
 
         try {
-            Files.walkFileTree(Path.of(BASE_DIR), new SimpleFileVisitor<Path>() {
+            Files.walkFileTree(Path.of(this.args.m2RepositoryPath), new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
 

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryArgs.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryArgs.java
@@ -4,7 +4,7 @@ import com.beust.jcommander.Parameter;
 
 public class CleanUpM2RepositoryArgs {
 
-    @Parameter(names= "--m2repo.path", arity = 1)
-    public String m2RepositoryPath = "~/.m2/repository";
+    @Parameter(names= "--path.m2", arity = 1)
+    public String pathM2 = "~/.m2/repository";
 
 }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryArgs.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryArgs.java
@@ -1,0 +1,10 @@
+package eu.f4sten.pomanalyzer;
+
+import com.beust.jcommander.Parameter;
+
+public class CleanUpM2RepositoryArgs {
+
+    @Parameter(names= "--m2repo.path", arity = 1)
+    public String m2RepositoryPath;
+
+}

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryArgs.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryArgs.java
@@ -5,6 +5,6 @@ import com.beust.jcommander.Parameter;
 public class CleanUpM2RepositoryArgs {
 
     @Parameter(names= "--m2repo.path", arity = 1)
-    public String m2RepositoryPath;
+    public String m2RepositoryPath = "~/.m2/repository";
 
 }

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryInjectorConfig.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryInjectorConfig.java
@@ -1,0 +1,18 @@
+package eu.f4sten.pomanalyzer;
+
+import com.google.inject.Binder;
+import eu.f4sten.infra.IInjectorConfig;
+import eu.f4sten.infra.InjectorConfig;
+
+@InjectorConfig
+public class CleanUpM2RepositoryInjectorConfig implements IInjectorConfig {
+
+    private CleanUpM2RepositoryArgs args;
+
+    public CleanUpM2RepositoryInjectorConfig(CleanUpM2RepositoryArgs args) {this.args = args;}
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(CleanUpM2RepositoryArgs.class).toInstance(args);
+    }
+}

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryInjectorConfig.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/CleanUpM2RepositoryInjectorConfig.java
@@ -9,7 +9,9 @@ public class CleanUpM2RepositoryInjectorConfig implements IInjectorConfig {
 
     private CleanUpM2RepositoryArgs args;
 
-    public CleanUpM2RepositoryInjectorConfig(CleanUpM2RepositoryArgs args) {this.args = args;}
+    public CleanUpM2RepositoryInjectorConfig(CleanUpM2RepositoryArgs args) {
+        this.args = args;
+    }
 
     @Override
     public void configure(Binder binder) {


### PR DESCRIPTION
This is a very small PR to clean up the .m2 folder at arbitrary paths.
Note that in production we store POM files at a different path not in the home folder as K8s pods store data at `/mnt/fasten/data`.