### PR TITLE
Add debugging info to the Maven compiler flags

### DIFF
--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -65,8 +65,8 @@
                     <version>3.8.0</version>
                     <configuration>
                         <release>11</release>
-                        <compilerArgument>-g:vars</compilerArgument>
-                        <testCompilerArgument>-g:vars</testCompilerArgument>
+                        <compilerArgument>-g:source,lines,vars</compilerArgument>
+                        <testCompilerArgument>-g:source,lines,vars</testCompilerArgument>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
This PR adds `g:source,lines,vars` to the Maven compiler plugin's flags so that we can debug the code in the IDEs.
I have tested this within Intelijj and it enables debugging.