### PR TITLE
Increase Kafka's request timeout to avoid disconnect exception

### DIFF
--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
@@ -29,6 +29,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_INSTANCE_ID
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 
 import java.security.InvalidParameterException;
@@ -88,6 +89,7 @@ public class KafkaConnector {
         p.setProperty(MAX_POLL_RECORDS_CONFIG, "1");
         p.setProperty(ENABLE_AUTO_COMMIT_CONFIG, "false");
         p.setProperty(AUTO_COMMIT_INTERVAL_MS_CONFIG, "0");
+        p.setProperty(REQUEST_TIMEOUT_MS_CONFIG, "60000");
 
         p.setProperty(MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS);
 

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
@@ -28,6 +28,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_INSTANCE_ID
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -125,6 +126,7 @@ public class KafkaConnectorTest {
             expected.setProperty(MAX_POLL_INTERVAL_MS_CONFIG, Integer.toString(1000 * 60 * 30));
             expected.setProperty(ENABLE_AUTO_COMMIT_CONFIG, "false");
             expected.setProperty(AUTO_COMMIT_INTERVAL_MS_CONFIG, "0");
+            expected.setProperty(REQUEST_TIMEOUT_MS_CONFIG, "60000");
 
             assertEquals(expected, actual);
         }


### PR DESCRIPTION
This is a tiny PR, which increases `request.timeout.ms` to 1 minute to prevent Kafka's disconnect exception. This should also resolve #24. 