### PR TITLE
Bump core dependency to 0.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>eu.fasten</groupId>
             <artifactId>core</artifactId>
-            <version>0.0.8</version>
+            <version>0.0.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
I have bumped the core dependency to version 0.0.13 to make it possible to leverage the recent changes.