### PR TITLE
Fix source provider test that relies on fixed order in file names

### DIFF
--- a/plugins/sources-provider/src/test/java/eu/f4sten/sourcesprovider/utils/SourcesJarProviderTest.java
+++ b/plugins/sources-provider/src/test/java/eu/f4sten/sourcesprovider/utils/SourcesJarProviderTest.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static eu.fasten.core.utils.TestUtils.getTestResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,9 +70,11 @@ class SourcesJarProviderTest {
         var sourcesPath = provider.downloadSourcesJar(mavenId, testUrl);
         assertNotNull(sourcesPath);
         var files = new File(sourcesPath).listFiles();
-        assertNotNull(files);
-        assertEquals("META-INF", files[0].getName());
-        assertEquals("org", files[1].getName());
+        var actuals = Arrays.stream(files) //
+                .map(f -> f.getName()) //
+                .collect(Collectors.toSet());
+        var expecteds = Set.of("META-INF", "org");
+        assertEquals(expecteds, actuals);
     }
 
     @AfterEach


### PR DESCRIPTION
The test in question relies on a fixed order of the file names... on my machine, this order differs, so the test fails locally. I am not sure if this is a macOS peculiarity (macOS 12.4) or whether this is specific to my JVM (openjdk 13.0.2 2020-01-14). I have fixed the issue by testing for the existence of all folders through a set instead of testing explicit indices. The null case is omitted, as it will crash with an NPE anyway (thus, failing the test).