### PR TITLE
Improve handling of DB errors in PomAnalyzer

### DIFF
--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/Main.java
@@ -123,9 +123,10 @@ public class Main implements Plugin {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
-            // this should not happen
             var cause = e.getCause();
-            if (cause instanceof RuntimeException) {
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            } else if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
             } else {
                 throw new RuntimeException(cause);

--- a/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/PomExtractorTest.java
+++ b/plugins/pom-analyzer/src/test/java/eu/f4sten/pomanalyzer/utils/PomExtractorTest.java
@@ -31,6 +31,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import eu.f4sten.test.TestLoggerUtils;
 import eu.fasten.core.maven.data.Dependency;
 import eu.fasten.core.maven.data.Exclusion;
 import eu.fasten.core.maven.data.Pom;
@@ -125,6 +126,20 @@ public class PomExtractorTest {
         expected.dependencies.add(depC(7, "(,1.0]", "[1.2)"));
         expected.dependencies.add(depC(8, "(,1.1)", "(1.1,)"));
         assertEquals(expected.pom(), actual);
+    }
+
+    @Test
+    public void dependenciesWithProperty() {
+        TestLoggerUtils.clearLog();
+
+        var actual = extract("dependencies-properties.pom");
+        var expected = getMinimal();
+        expected.dependencies.add(depC(1, "1"));
+        expected.dependencies.add(depC(3, "3"));
+        assertEquals(expected.pom(), actual);
+
+        TestLoggerUtils.assertLogsContain(PomExtractor.class,
+                "ERROR Ignoring dependency 'g2:a2' -- Failed to parse version spec '${some.unresolved.property}'");
     }
 
     @Test
@@ -275,7 +290,7 @@ public class PomExtractorTest {
                 "");
     }
 
-    private Dependency depC(int i, String... specs) {
+    private static Dependency depC(int i, String... specs) {
         var vcs = new LinkedHashSet<VersionConstraint>();
         for (var spec : specs) {
             vcs.add(new VersionConstraint(spec));

--- a/plugins/pom-analyzer/src/test/resources/PomExtractorTest/dependencies-properties.pom
+++ b/plugins/pom-analyzer/src/test/resources/PomExtractorTest/dependencies-properties.pom
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>test</groupId>
+	<artifactId>PomAnalyzerTest</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	
+	<dependencies>
+		<dependency>
+			<groupId>g1</groupId>
+			<artifactId>a1</artifactId>
+			<version>1</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>g2</groupId>
+			<artifactId>a2</artifactId>
+			<version>${some.unresolved.property}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>g3</groupId>
+			<artifactId>a3</artifactId>
+			<version>3</version>
+		</dependency>
+	
+	</dependencies>
+
+</project>


### PR DESCRIPTION
Right now, the `PomAnalyzer` is very fragile for two main reasons.

1) When it come to DB failures (e.g., lost connection due to restart). Unfortunately, in presence of such a failure, the current implementation just silently failed and consumed all remaining Kafka messages. This PR improves the handling of DB errors in the `PomAnalyzer`... DB related errors are caught and treated as unrecoverable, they lead to a termination of the process (and an automated restart).

2) Errors in transitive dependencies have crashed the processing of the whole originating package. These errors are deterministic (e.g., parsing errors), so restarting does not help. We decided to focus on improving the coverage from the DB perspective and now continue with processing the transitive closure. The failing package will be logged, but otherwise skipped from processing, so we can at least investigate how often such cases occur in practice.

*Please note:* a failing dependency will still be captured as a formal dependency in the `Pom` data structure that is extracted from the originating artifact, so down-stream analysis tasks might face the situation, where a dependency in the resolved dependency set has been consumed, but is not available.