### PR TITLE
Add a default topic to the `sources-provider` plugin

### DIFF
--- a/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/kafka/DefaultTopics.java
+++ b/infrastructure/infrastructure/src/main/java/eu/f4sten/infra/kafka/DefaultTopics.java
@@ -25,4 +25,5 @@ public class DefaultTopics {
     public static final String POM_ANALYZER = "fasten.POMAnalyzer";
     public static final String CALLABLE_INDEXER = "fasten.CallableIndexFastenPlugin";
     public static final String SOURCES_PROVIDER = "fasten.SourcesProvider";
+    public static final String METADATA_DB_JAVA = "fasten.MetadataDBJavaExtension";
 }

--- a/plugins/sources-provider/src/main/java/eu/f4sten/sourcesprovider/SourcesProviderArgs.java
+++ b/plugins/sources-provider/src/main/java/eu/f4sten/sourcesprovider/SourcesProviderArgs.java
@@ -21,7 +21,7 @@ import eu.f4sten.infra.kafka.DefaultTopics;
 public class SourcesProviderArgs {
 
     @Parameter(names = "--sourcesprovider.kafkaIn", arity = 1)
-    public String kafkaIn;
+    public String kafkaIn = DefaultTopics.METADATA_DB_JAVA;
 
     @Parameter(names = "--sourcesprovider.kafkaOut", arity = 1)
     public String kafkaOut = DefaultTopics.SOURCES_PROVIDER;


### PR DESCRIPTION
This is a tiny PR to add a default topic to `sources-provider`, which is `fasten.MetadataDBJavaExtension`. Other plugins also have a default Kafka topic.