### PR TITLE
Adding SWH-compatible hash for source files of package versions

### DIFF
--- a/infrastructure/loader/pom.xml
+++ b/infrastructure/loader/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>sources-provider</artifactId>
             <version>0.0.12-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>eu.fasten-project</groupId>
+            <artifactId>swh-inserter</artifactId>
+            <version>0.0.12-SNAPSHOT</version>
+        </dependency>
 
         <!-- actual dependencies -->
         <dependency>

--- a/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/DatabaseUtils.java
+++ b/plugins/pom-analyzer/src/main/java/eu/f4sten/pomanalyzer/utils/DatabaseUtils.java
@@ -18,13 +18,8 @@ package eu.f4sten.pomanalyzer.utils;
 import static eu.fasten.core.maven.utils.MavenUtilities.MAVEN_CENTRAL_REPO;
 
 import java.sql.Timestamp;
-import java.util.List;
 
-import eu.fasten.core.data.metadatadb.codegen.tables.Files;
-import eu.fasten.core.data.metadatadb.codegen.tables.PackageVersions;
-import eu.fasten.core.data.metadatadb.codegen.tables.Packages;
 import org.jooq.DSLContext;
-import org.jooq.JSONB;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 
@@ -35,7 +30,6 @@ import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.exceptions.UnrecoverableError;
 import eu.fasten.core.maven.data.Pom;
-import org.json.JSONObject;
 
 public class DatabaseUtils {
 
@@ -144,42 +138,6 @@ public class DatabaseUtils {
     public void pruneRetries(String key) {
         try {
             getDao(context).pruneIngestionRetries(key);
-        } catch (DataAccessException e) {
-            throw new UnrecoverableError(e);
-        }
-    }
-
-    public Long getPkgVersionID(String pkgName, String version) {
-        try {
-            var pkgVerID = context.select(PackageVersions.PACKAGE_VERSIONS.ID).
-                    from(Packages.PACKAGES, PackageVersions.PACKAGE_VERSIONS).
-                    where(Packages.PACKAGES.PACKAGE_NAME.eq(pkgName).
-                                    and(PackageVersions.PACKAGE_VERSIONS.PACKAGE_ID.eq(Packages.PACKAGES.ID)).
-                                    and(PackageVersions.PACKAGE_VERSIONS.VERSION.eq(version))).fetchOne();
-            // May produce null pointer exception
-            return pkgVerID.component1();
-        } catch (DataAccessException e) {
-            throw new UnrecoverableError(e);
-        }
-    }
-
-    public List<String> getFilePaths4PkgVersion(Long pkgVersionID) {
-        try {
-            var filePaths = context.select(Files.FILES.PATH).
-                    from(Files.FILES).where(Files.FILES.PACKAGE_VERSION_ID.eq(pkgVersionID)).fetch();
-            return filePaths.getValues(Files.FILES.PATH);
-        } catch (DataAccessException e) {
-            throw new UnrecoverableError(e);
-        }
-    }
-
-    public String addFileHash(Long pkgVersionID, String filePath, String fileHash) {
-        try {
-            var fileMetadata = JSONB.valueOf(String.valueOf(new JSONObject().put("swh_checksum", fileHash)));
-            return context.update(Files.FILES).
-                    set(Files.FILES.METADATA, fileMetadata).
-                    where(Files.FILES.PACKAGE_VERSION_ID.eq(pkgVersionID).and(Files.FILES.PATH.eq(filePath))).
-                    returningResult(Files.FILES.PATH).fetchOne().getValue(Files.FILES.PATH);
         } catch (DataAccessException e) {
             throw new UnrecoverableError(e);
         }

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -18,6 +18,7 @@
         <module>integration-tests</module>
         <module>ingested-artifact-completion</module>
         <module>sources-provider</module>
+        <module>swh-inserter</module>
     </modules>
 
     <dependencies>

--- a/plugins/sources-provider/src/main/java/eu/f4sten/sourcesprovider/data/SourcePayload.java
+++ b/plugins/sources-provider/src/main/java/eu/f4sten/sourcesprovider/data/SourcePayload.java
@@ -15,11 +15,22 @@
  */
 package eu.f4sten.sourcesprovider.data;
 
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 public class SourcePayload {
+
     private String forge;
     private String product;
     private String version;
     private String sourcePath;
+
+    public SourcePayload() {
+        // for object mappers
+    }
 
     public SourcePayload(String forge, String product, String version, String sourcePath) {
         setForge(forge);
@@ -58,5 +69,20 @@ public class SourcePayload {
 
     public void setSourcePath(String sourcePath) {
         this.sourcePath = sourcePath;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, MULTI_LINE_STYLE);
     }
 }

--- a/plugins/sources-provider/src/test/java/eu/f4sten/sourcesprovider/data/SourcePayloadTest.java
+++ b/plugins/sources-provider/src/test/java/eu/f4sten/sourcesprovider/data/SourcePayloadTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.sourcesprovider.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class SourcePayloadTest {
+
+    @Test
+    public void defaults1() {
+        var sut = new SourcePayload();
+        assertNull(sut.getForge());
+        assertNull(sut.getProduct());
+        assertNull(sut.getVersion());
+        assertNull(sut.getSourcePath());
+    }
+
+    @Test
+    public void defaults2() {
+        var sut = new SourcePayload("f", "p:q", "1.2.3", "/a/b/c");
+        assertEquals("f", sut.getForge());
+        assertEquals("p:q", sut.getProduct());
+        assertEquals("1.2.3", sut.getVersion());
+        assertEquals("/a/b/c", sut.getSourcePath());
+    }
+
+    @Test
+    public void setForge() {
+        var sut = new SourcePayload();
+        sut.setForge("f");
+        assertEquals("f", sut.getForge());
+    }
+
+    @Test
+    public void setProduct() {
+        var sut = new SourcePayload();
+        sut.setProduct("p:q");
+        assertEquals("p:q", sut.getProduct());
+    }
+
+    @Test
+    public void setVersion() {
+        var sut = new SourcePayload();
+        sut.setVersion("1.2.3");
+        assertEquals("1.2.3", sut.getVersion());
+    }
+
+    @Test
+    public void setSourcePath() {
+        var sut = new SourcePayload();
+        sut.setSourcePath("/a/b/c");
+        assertEquals("/a/b/c", sut.getSourcePath());
+    }
+
+    @Test
+    public void equalityDefault() {
+        var a = new SourcePayload();
+        var b = new SourcePayload();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void equalityNonDefault() {
+        var a = new SourcePayload("f", "p:q", "1.2.3", "/a/b/c");
+        var b = new SourcePayload("f", "p:q", "1.2.3", "/a/b/c");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void toStringIsImplemented() {
+        var actual = new SourcePayload().toString();
+        assertTrue(actual.contains(SourcePayload.class.getSimpleName()));
+        assertTrue(actual.contains("\n"));
+        assertTrue(actual.contains("forge"));
+        assertTrue(actual.contains("@"));
+    }
+}

--- a/plugins/swh-inserter/pom.xml
+++ b/plugins/swh-inserter/pom.xml
@@ -2,18 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>eu.fasten-project</groupId>
         <version>0.0.12-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>swh-inserter</artifactId>
+
     <dependencies>
         <dependency>
             <groupId>eu.fasten-project</groupId>
-            <artifactId>pom-analyzer</artifactId>
+            <artifactId>sources-provider</artifactId>
             <version>0.0.12-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>

--- a/plugins/swh-inserter/pom.xml
+++ b/plugins/swh-inserter/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugins</artifactId>
+        <groupId>eu.fasten-project</groupId>
+        <version>0.0.12-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>swh-inserter</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>eu.fasten-project</groupId>
+            <artifactId>pom-analyzer</artifactId>
+            <version>0.0.12-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/DatabaseUtils.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/DatabaseUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.swhinserter;
+
+import java.util.List;
+
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.exception.DataAccessException;
+import org.json.JSONObject;
+
+import eu.fasten.core.data.metadatadb.codegen.tables.Files;
+import eu.fasten.core.data.metadatadb.codegen.tables.PackageVersions;
+import eu.fasten.core.data.metadatadb.codegen.tables.Packages;
+import eu.fasten.core.exceptions.UnrecoverableError;
+
+public class DatabaseUtils {
+
+    private final DSLContext context;
+
+    public DatabaseUtils(DSLContext context) {
+        this.context = context;
+    }
+
+    public Long getPkgVersionID(String pkgName, String version) {
+        try {
+            var pkgVerID = context.select(PackageVersions.PACKAGE_VERSIONS.ID)
+                    .from(Packages.PACKAGES, PackageVersions.PACKAGE_VERSIONS)
+                    .where(Packages.PACKAGES.PACKAGE_NAME.eq(pkgName)
+                            .and(PackageVersions.PACKAGE_VERSIONS.PACKAGE_ID.eq(Packages.PACKAGES.ID))
+                            .and(PackageVersions.PACKAGE_VERSIONS.VERSION.eq(version)))
+                    .fetchOne();
+            // May produce null pointer exception
+            return pkgVerID.component1();
+        } catch (DataAccessException e) {
+            throw new UnrecoverableError(e);
+        }
+    }
+
+    public List<String> getFilePaths4PkgVersion(Long pkgVersionID) {
+        try {
+            var filePaths = context.select(Files.FILES.PATH).from(Files.FILES)
+                    .where(Files.FILES.PACKAGE_VERSION_ID.eq(pkgVersionID)).fetch();
+            return filePaths.getValues(Files.FILES.PATH);
+        } catch (DataAccessException e) {
+            throw new UnrecoverableError(e);
+        }
+    }
+
+    public String addFileHash(Long pkgVersionID, String filePath, String fileHash) {
+        try {
+            var fileMetadata = JSONB.valueOf(String.valueOf(new JSONObject().put("swh_checksum", fileHash)));
+            return context.update(Files.FILES).set(Files.FILES.METADATA, fileMetadata)
+                    .where(Files.FILES.PACKAGE_VERSION_ID.eq(pkgVersionID).and(Files.FILES.PATH.eq(filePath)))
+                    .returningResult(Files.FILES.PATH).fetchOne().getValue(Files.FILES.PATH);
+        } catch (DataAccessException e) {
+            throw new UnrecoverableError(e);
+        }
+    }
+}

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/Main.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/Main.java
@@ -68,12 +68,12 @@ public class Main implements Plugin {
         }
     }
 
-    private void consume(SourcePayload payload, Lane lane) {
+    public void consume(SourcePayload payload, Lane lane) {
         LOG.info("Consuming next {} record ...", lane);
         var pkgName = payload.getProduct();
         var ver = payload.getVersion();
 
-        var basePath = getBasePath(pkgName, ver);
+        var basePath = getBasePath(payload.getForge(), pkgName, ver);
 
         var pkgVerID = db.getPkgVersionID(pkgName, ver);
         var paths = db.getFilePaths4PkgVersion(pkgVerID);
@@ -85,13 +85,13 @@ public class Main implements Plugin {
         });
     }
 
-    private File getBasePath(String pkgName, String version) {
+    private File getBasePath(String forge, String pkgName, String version) {
         String[] ga = pkgName.split(":");
         var groupID = ga[0];
         var artifactID = ga[1];
-        var baseDir = io.getBaseFolder().getAbsolutePath();
+        var baseDir = io.getBaseFolder().getPath();
         var firstChar = Character.toString(groupID.charAt(0));
-        var basePath = Path.of(baseDir, "sources", "mvn", firstChar, groupID, artifactID, version).toFile();
+        var basePath = Path.of(baseDir, "sources", forge, firstChar, groupID, artifactID, version).toFile();
         return basePath;
     }
 }

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/Main.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/Main.java
@@ -1,0 +1,104 @@
+package eu.f4sten.swhinserter;
+
+import eu.f4sten.infra.AssertArgs;
+import eu.f4sten.infra.Plugin;
+import eu.f4sten.infra.kafka.Kafka;
+import eu.f4sten.infra.kafka.Lane;
+import eu.f4sten.infra.utils.IoUtils;
+import eu.f4sten.pomanalyzer.utils.DatabaseUtils;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+
+public class Main implements Plugin {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+    private final SwhInserterArgs args;
+    private final Kafka kafka;
+    private final DatabaseUtils db;
+    private final IoUtils io;
+
+    @Inject
+    public Main(SwhInserterArgs args, Kafka kafka, DatabaseUtils db, IoUtils io) {
+        this.args = args;
+        this.kafka = kafka;
+        this.db = db;
+        this.io = io;
+    }
+
+    @Override
+    public void run() {
+
+        try {
+            AssertArgs.assertFor(args)//
+                    .notNull(a -> a.kafkaIn, "kafka input topic"); //
+
+            LOG.info("Subscribing to '{}'", args.kafkaIn);
+            kafka.subscribe(args.kafkaIn, LinkedHashMap.class, this::consume);
+            while (true) {
+                LOG.debug("Polling ...");
+                kafka.poll();
+            }
+        } finally {
+            kafka.stop();
+        }
+    }
+
+    private void consume(LinkedHashMap<String, String> message, Lane lane) {
+        var json = new JSONObject(message);
+        LOG.info("Consuming next {} record {} ...", lane, json);
+        var pkgName = json.get("product").toString();
+        var ver = json.get("version").toString();
+        //var srcPath = json.get("version").toString();
+
+        var pkgVerID = db.getPkgVersionID(pkgName, ver);
+        var pkgVerFilesPaths = db.getFilePaths4PkgVersion(pkgVerID);
+
+        pkgVerFilesPaths.forEach(fp -> {
+            LOG.info("P: {}", fp);
+            var srcFileContent = readSrcFileContent(pkgName, ver, fp);
+            var srcFileHash = computeGitHash(srcFileContent.getBytes(StandardCharsets.UTF_8));
+            db.addFileHash(pkgVerID, fp, srcFileHash);
+            LOG.info("Added file hash for {}", fp);
+        });
+    }
+
+    private String readSrcFileContent(String pkgName, String version, String filePath) {
+        String[] ga = pkgName.split(":");
+        var groupID = ga[0];
+        var artifactID = ga[1];
+        var baseDir = io.getBaseFolder();
+        var srcFile = new File(Path.of(baseDir.toString(), "sources", "mvn", Character.toString(groupID.charAt(0)),
+                groupID, artifactID, version, filePath).toString());
+        try {
+            return FileUtils.readFileToString(srcFile, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not read the file " + srcFile.toPath());
+        }
+    }
+
+    // This method computes a SWH-compatible hash
+    private String computeGitHash(byte[] fileContent) {
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        md.update(String.format("blob %d\u0000", fileContent.length).getBytes());
+        md.update(fileContent);
+        return Hex.encodeHexString(md.digest());
+    }
+}

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhHashCalculator.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhHashCalculator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.swhinserter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.FileUtils;
+
+public class SwhHashCalculator {
+
+    public String calc(File basePath, String path) {
+
+        if (path.startsWith("/")) {
+            throw new IllegalArgumentException("path must be relative, was: " + path);
+        }
+
+        var content = read(basePath, path);
+        var bytes = content.getBytes(StandardCharsets.UTF_8);
+        var hash = computeSwhHash(bytes);
+        return hash;
+    }
+
+    private String read(File base, String path) {
+        try {
+            var f = new File(base, path);
+            if (!f.exists()) {
+                throw new IllegalStateException("File does not exist: " + f.getAbsolutePath());
+            }
+            return FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String computeSwhHash(byte[] fileContent) {
+        var md = getSha1Digest();
+        // The SWH hash is based on Git, which saltes the content with "blob"
+        md.update(String.format("blob %d\u0000", fileContent.length).getBytes());
+        md.update(fileContent);
+        return Hex.encodeHexString(md.digest());
+    }
+
+    private static MessageDigest getSha1Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterArgs.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterArgs.java
@@ -1,0 +1,9 @@
+package eu.f4sten.swhinserter;
+
+import com.beust.jcommander.Parameter;
+import eu.f4sten.infra.kafka.DefaultTopics;
+
+public class SwhInserterArgs {
+        @Parameter(names = "--swhinserter.kafkaIn", arity = 1)
+        public String kafkaIn = DefaultTopics.SOURCES_PROVIDER;
+}

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterArgs.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterArgs.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2022 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.f4sten.swhinserter;
 
 import com.beust.jcommander.Parameter;
+
 import eu.f4sten.infra.kafka.DefaultTopics;
 
 public class SwhInserterArgs {
-        @Parameter(names = "--swhinserter.kafkaIn", arity = 1)
-        public String kafkaIn = DefaultTopics.SOURCES_PROVIDER;
+    @Parameter(names = "--swhinserter.kafkaIn", arity = 1)
+    public String kafkaIn = DefaultTopics.SOURCES_PROVIDER;
 }

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterInjectorConfig.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterInjectorConfig.java
@@ -1,8 +1,31 @@
+/*
+ * Copyright 2022 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.f4sten.swhinserter;
 
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
 import com.google.inject.Binder;
+import com.google.inject.Provides;
+
 import eu.f4sten.infra.IInjectorConfig;
 import eu.f4sten.infra.InjectorConfig;
+import eu.f4sten.infra.json.JsonUtils;
+import eu.f4sten.infra.utils.PostgresConnector;
+import eu.f4sten.infra.utils.Version;
 
 @InjectorConfig
 public class SwhInserterInjectorConfig implements IInjectorConfig {
@@ -18,4 +41,10 @@ public class SwhInserterInjectorConfig implements IInjectorConfig {
         binder.bind(SwhInserterArgs.class).toInstance(args);
     }
 
+    @Provides
+    public DatabaseUtils bindDatabaseUtils(PostgresConnector pc, JsonUtils json, Version version) {
+        var c = pc.getNewConnection();
+        var dslContext = DSL.using(c, SQLDialect.POSTGRES);
+        return new DatabaseUtils(dslContext);
+    }
 }

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterInjectorConfig.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhInserterInjectorConfig.java
@@ -1,0 +1,21 @@
+package eu.f4sten.swhinserter;
+
+import com.google.inject.Binder;
+import eu.f4sten.infra.IInjectorConfig;
+import eu.f4sten.infra.InjectorConfig;
+
+@InjectorConfig
+public class SwhInserterInjectorConfig implements IInjectorConfig {
+
+    private SwhInserterArgs args;
+
+    public SwhInserterInjectorConfig(SwhInserterArgs args) {
+        this.args = args;
+    }
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(SwhInserterArgs.class).toInstance(args);
+    }
+
+}

--- a/plugins/swh-inserter/src/test/java/eu/f4sten/swhinserter/MainTest.java
+++ b/plugins/swh-inserter/src/test/java/eu/f4sten/swhinserter/MainTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.f4sten.swhinserter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import eu.f4sten.infra.kafka.Kafka;
+import eu.f4sten.infra.kafka.Lane;
+import eu.f4sten.infra.utils.IoUtils;
+import eu.f4sten.sourcesprovider.data.SourcePayload;
+
+public class MainTest {
+
+    private static final File SOMEBASE = new File("BASE");
+    private static final String SOMEHASH = "12345";
+    private Main sut;
+    private DatabaseUtils db;
+    private IoUtils io;
+    private SwhHashCalculator hash;
+
+    @BeforeEach
+    public void setup() {
+        var args = new SwhInserterArgs();
+        var kafka = mock(Kafka.class);
+        db = mock(DatabaseUtils.class);
+        io = mock(IoUtils.class);
+        when(io.getBaseFolder()).thenReturn(SOMEBASE);
+
+        hash = mock(SwhHashCalculator.class);
+        when(hash.calc(any(File.class), anyString())).thenReturn(SOMEHASH);
+        sut = new Main(args, kafka, db, io, hash);
+    }
+
+    @Test
+    public void consume() {
+
+        registerPackageVersion("prod:art", "1.2.3", 123);
+        registerPaths(123, "a/b/c.txt");
+
+        var p = new SourcePayload("forge", "prod:art", "1.2.3", "a/b/c.txt");
+        sut.consume(p, Lane.NORMAL);
+
+        var captor = ArgumentCaptor.forClass(File.class);
+        verify(hash).calc(captor.capture(), anyString());
+
+        var expected = new File("BASE/sources/forge/p/prod/art/1.2.3");
+        var actual = captor.getValue();
+        assertEquals(expected, actual);
+
+        verify(db).addFileHash(eq(123L), eq("a/b/c.txt"), eq(SOMEHASH));
+    }
+
+    private void registerPackageVersion(String pkg, String v, long id) {
+        when(db.getPkgVersionID(eq(pkg), eq(v))).thenReturn(id);
+    }
+
+    private void registerPaths(long id, String... paths) {
+        when(db.getFilePaths4PkgVersion(eq(id))).thenReturn(Arrays.asList(paths));
+    }
+}

--- a/plugins/swh-inserter/src/test/java/eu/f4sten/swhinserter/SwhHashCalculatorTest.java
+++ b/plugins/swh-inserter/src/test/java/eu/f4sten/swhinserter/SwhHashCalculatorTest.java
@@ -1,0 +1,97 @@
+package eu.f4sten.swhinserter;
+/*
+ * Copyright 2022 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SwhHashCalculatorTest {
+
+    @TempDir
+    public File root;
+    private SwhHashCalculator sut;
+
+    @BeforeEach
+    public void setup() {
+        sut = new SwhHashCalculator();
+    }
+
+    @Test
+    public void failsOnTrailingSlash() throws IOException {
+        var e = assertThrows(IllegalArgumentException.class, () -> {
+            sut.calc(root, "/a/b.txt");
+        });
+        var msg = e.getMessage();
+        assertTrue(msg.contains("path must be relative"));
+        assertTrue(msg.contains("/a/b.txt"));
+    }
+
+    @Test
+    public void happypath() throws IOException {
+        var sub = new File(root, "a");
+
+        sub.mkdir();
+        var f = new File(sub, "b.txt");
+        FileUtils.writeStringToFile(f, "abc", StandardCharsets.UTF_8);
+
+        var actual = sut.calc(root, path("a", "b.txt"));
+        // created via: git init && git hash-object -w a/b.txt
+        var expected = "f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void subsubfolder() throws IOException {
+        var sub = new File(root, "a");
+        var subsub = new File(sub, "b");
+        subsub.mkdirs();
+
+        var f = new File(subsub, "c.txt");
+        FileUtils.writeStringToFile(f, "abc", StandardCharsets.UTF_8);
+
+        var actual = sut.calc(root, path("a", "b", "c.txt"));
+        // created via: git init && git hash-object -w a/b.txt
+        var expected = "f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void pathDoesNotExist() {
+        var e = assertThrows(IllegalStateException.class, () -> {
+            sut.calc(root, path("a", "b.txt"));
+        });
+
+        var msg = e.getMessage();
+        assertTrue(msg.contains("File does not exist"));
+        assertTrue(msg.contains(root.getAbsolutePath()));
+        assertTrue(msg.contains(path("a", "b.txt")));
+    }
+
+    private static String path(String first, String... more) {
+        return Path.of(first, more).toString();
+    }
+}


### PR DESCRIPTION
This PR is a proof of concept to address https://github.com/fasten-project/fasten/issues/102. A small plugin, `swh-inserter`, is created to add an SWH-compatible hash to the files in the metadata DB.

The plugin performs the following steps in order to update the metadata DB with SWH-compatible file hashes:
1.  Given a package version from `fasten.SourcesProvider.*`, find its package version ID in the metadata DB.
2.  From the metadata DB, retrieve the file paths for the package version ID in step 1.
3.  For each file in step 2, do:
  3.1. read its source code file from the disk.
  3.2. compute an SWH-compatible hash for the source code in step 3.1.
  3.3 insert the obtained file hash into the `metadata` field of the `files` table by adding`{'swh_checksum'}`.

## Testing
The implementation is tested using the DC. Also, for several random files, the computed hash in the DB is compared with `git hash-object -w` and they match.