### PR TITLE
Catch errors for individual files to prevent crash of whole coordinate

### DIFF
--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/Main.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/Main.java
@@ -16,6 +16,7 @@
 package eu.f4sten.swhinserter;
 
 import java.io.File;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 
 import javax.inject.Inject;
@@ -79,9 +80,13 @@ public class Main implements Plugin {
         var paths = db.getFilePaths4PkgVersion(pkgVerID);
 
         paths.forEach(path -> {
-            var hash = calc.calc(basePath, path);
-            db.addFileHash(pkgVerID, path, hash);
-            LOG.info("Added file hash for {}", path);
+            try {
+                var hash = calc.calc(basePath, path);
+                db.addFileHash(pkgVerID, path, hash);
+                LOG.info("Added file hash for {}", path);
+            } catch (UncheckedIOException | IllegalStateException e) {
+                LOG.error("Unable to process '{}' ({}: {})", path, e.getClass(), e.getMessage());
+            }
         });
     }
 

--- a/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhHashCalculator.java
+++ b/plugins/swh-inserter/src/main/java/eu/f4sten/swhinserter/SwhHashCalculator.java
@@ -17,6 +17,7 @@ package eu.f4sten.swhinserter;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -46,7 +47,7 @@ public class SwhHashCalculator {
             }
             return FileUtils.readFileToString(f, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 


### PR DESCRIPTION
Failures in individual files crash the processing of a whole coordinate right now. Unfortunately, the DB can contain entries for which we do not have source code, so instead of registering the whole coordinate as failed in the error topic, we log the error and continue with the remaining files...