### PR TITLE
Allow setting a custom Kafka group id

### DIFF
--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraArgs.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/InfraArgs.java
@@ -36,6 +36,9 @@ public class InfraArgs {
     @Parameter(names = "--kafka.autoCommit", arity = 1, description = "should Kafka auto-commit after each poll")
     public boolean kafkaShouldAutoCommit = true;
 
+    @Parameter(names = "--kafka.groupId", arity = 1, description = "optional id for Kafka consumer group")
+    public String kafkaGroupId = null;
+
     @Parameter(names = "--instanceId", arity = 1, description = "uniquely identifies this application instance across re-starts")
     public String instanceId = null;
 

--- a/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
+++ b/infrastructure/infrastructure-impl/src/main/java/eu/f4sten/infra/impl/kafka/KafkaConnector.java
@@ -108,7 +108,8 @@ public class KafkaConnector {
 
     private String getGroupId(Lane lane) {
         var suffix = lane == Lane.PRIORITY ? "-prio" : "";
-        return format("%s%s", activePlugin, suffix);
+        var base = args.kafkaGroupId != null ? args.kafkaGroupId : activePlugin;
+        return format("%s%s", base, suffix);
     }
 
     private String getFullInstanceId(Lane lane) {

--- a/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
+++ b/infrastructure/infrastructure-impl/src/test/java/eu/f4sten/infra/impl/kafka/KafkaConnectorTest.java
@@ -166,6 +166,17 @@ public class KafkaConnectorTest {
     }
 
     @Test
+    public void groupIdCanBeEnforced() {
+
+        infraArgs.kafkaGroupId = "someGroup";
+        sut = new KafkaConnector(loaderArgs, infraArgs);
+
+        var actual = sut.getConsumerProperties(PRIORITY).getProperty(GROUP_ID_CONFIG);
+        var expected = "someGroup-prio";
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void instanceIdIsSetNormal() {
         infraArgs.instanceId = "X";
         var expected = "p-X";


### PR DESCRIPTION
So far, the group id has been auto-inferred from the started plugin. Unfortunately, this leads to collisions when two instances of the same plugin are supposed to process Kafka messages separately from each other. For example, a production plugin and a derived version of the production plugin that we want to use for testing something. When operating both with the same groupId, both would consume messages from the same group and move the index, which leads to missed messages on both sides. To solve this situation, this change introduces the (optional) `--kafka.groupId` switch to the loader infrastructure that allows to set the groupId, instead of inferring it.