### PR TITLE
Add JVM options to the loader in the Docker file

### DIFF
--- a/infrastructure/loader/Dockerfile
+++ b/infrastructure/loader/Dockerfile
@@ -5,4 +5,4 @@ COPY target/lib lib
 # having multiple .jars (e.g., *-sources.jar) breaks this cmd
 COPY target/*.jar server.jar
 
-ENTRYPOINT ["java", "-jar", "server.jar"]
+ENTRYPOINT exec java $JAVA_OPTS -jar server.jar $0 $@


### PR DESCRIPTION
This is a tiny PR to pass JVM options to the docker container that runs the loader. This was done before for the legacy FASTEN server and the REST API. This basically enables passing JVM options as an ENV. variable in K8s manifest files for choosing min/max heap size and etc.